### PR TITLE
Bump client version and tighten test typings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 1.5.1
+
+### Patch Changes
+
+- Added weekly email digest feature: `WeeklyDigestService` generates personalised summaries of new places and activity; new `system:weekly-digest` CLI command sends digests to opted-in users; digest send history tracked in `user_digest_logs` to prevent duplicates
+- Added `emailDigest` notification preference setting; users can opt in/out via settings and unsubscribe via a dedicated endpoint (`POST /users/unsubscribe-digest`); unsubscribe link and i18n keys added to the digest email template
+- Improved email infrastructure: refactored `EmailLibrary` and email view templates, added mail config debug helpers, and introduced a `system:test-email` CLI command for verifying mail delivery
+- Added BIMI logo SVG for email brand identity support
+- Added root `GET /` API info endpoint returning service name, version, and environment
+- Fixed user listing responses to use total user count instead of filtered count, correcting pagination metadata
+- Added initials-based avatar fallback for users without an uploaded avatar photo
+- Refactored photo actions UI and header upload links for improved layout and consistency
+- Switched analytics scripts to `next/script` for better performance and loading control
+- Bumped client dependencies and set `bundler` module resolution in TypeScript config
+- Expanded client unit test coverage: added test mocks and unit tests for app-bar, layout, map, shared, UI kit components, `useClientOnly`, `useLocalStorage`, and client utility functions
+- Refactored test mocks and imports across the client test suite; standardised formatting and updated Jest config with new testing dependencies
+- Improved ESLint config and added SonarCloud coverage badges; updated Sonar exclusion rules
+- Added product ROADMAP documentation and expanded feature docs
+
 ## 1.5.0
 
 ### Minor Changes

--- a/client/components/shared/user-avatar/AvatarImage.test.tsx
+++ b/client/components/shared/user-avatar/AvatarImage.test.tsx
@@ -2,12 +2,26 @@ import React from 'react'
 
 import { render, screen } from '@testing-library/react'
 
+import { ApiModel } from '@/api'
 import { minutesAgo } from '@/utils/helpers'
 
 import { AvatarImage } from './AvatarImage'
 
 jest.mock('next/image', () => {
-    const Image = ({ src, alt, width, height, className }: any) => (
+    const Image = ({
+        src,
+        alt,
+        width,
+        height,
+        className
+    }: {
+        src: string
+        alt: string
+        width: number
+        height: number
+        className?: string
+    }) => (
+        // eslint-disable-next-line next/no-img-element
         <img
             src={src}
             alt={alt}
@@ -44,21 +58,21 @@ describe('AvatarImage', () => {
         })
 
         it('renders initials when user has no avatar', () => {
-            const { container } = render(<AvatarImage user={{ id: 'u1', name: 'Alice' } as any} />)
+            const { container } = render(<AvatarImage user={{ id: 'u1', name: 'Alice' } as ApiModel.User} />)
             const initialsDiv = container.querySelector('.initialsAvatar')
             expect(initialsDiv).toBeInTheDocument()
             expect(initialsDiv).toHaveTextContent('A')
         })
 
         it('renders initials from first two words of name', () => {
-            const { container } = render(<AvatarImage user={{ id: 'u1', name: 'John Doe' } as any} />)
+            const { container } = render(<AvatarImage user={{ id: 'u1', name: 'John Doe' } as ApiModel.User} />)
             const initialsDiv = container.querySelector('.initialsAvatar')
             expect(initialsDiv).toBeInTheDocument()
             expect(initialsDiv).toHaveTextContent('JD')
         })
 
         it('renders the user avatar image when avatar is provided', () => {
-            render(<AvatarImage user={{ id: 'u1', name: 'Alice', avatar: '/avatars/alice.jpg' } as any} />)
+            render(<AvatarImage user={{ id: 'u1', name: 'Alice', avatar: '/avatars/alice.jpg' } as ApiModel.User} />)
             expect(screen.getByRole('presentation')).toHaveAttribute('src', 'https://img.example.com/avatars/alice.jpg')
         })
     })
@@ -67,7 +81,9 @@ describe('AvatarImage', () => {
         it('renders the online indicator for recently active user', () => {
             mockMinutesAgo.mockReturnValue(5)
             const { container } = render(
-                <AvatarImage user={{ id: 'u1', name: 'Alice', activity: { date: '2026-03-27T10:00:00Z' } } as any} />
+                <AvatarImage
+                    user={{ id: 'u1', name: 'Alice', activity: { date: '2026-03-27T10:00:00Z' } } as ApiModel.User}
+                />
             )
             expect(container.querySelector('.online')).toBeInTheDocument()
         })
@@ -75,7 +91,9 @@ describe('AvatarImage', () => {
         it('does not render online indicator when last activity is more than 15 min ago', () => {
             mockMinutesAgo.mockReturnValue(20)
             const { container } = render(
-                <AvatarImage user={{ id: 'u1', name: 'Alice', activity: { date: '2026-03-27T10:00:00Z' } } as any} />
+                <AvatarImage
+                    user={{ id: 'u1', name: 'Alice', activity: { date: '2026-03-27T10:00:00Z' } } as ApiModel.User}
+                />
             )
             expect(container.querySelector('.online')).not.toBeInTheDocument()
         })
@@ -84,7 +102,7 @@ describe('AvatarImage', () => {
             mockMinutesAgo.mockReturnValue(5)
             const { container } = render(
                 <AvatarImage
-                    user={{ id: 'u1', name: 'Alice', activity: { date: '2026-03-27T10:00:00Z' } } as any}
+                    user={{ id: 'u1', name: 'Alice', activity: { date: '2026-03-27T10:00:00Z' } } as ApiModel.User}
                     hideOnlineIcon={true}
                 />
             )

--- a/client/components/shared/user-avatar/UserAvatar.test.tsx
+++ b/client/components/shared/user-avatar/UserAvatar.test.tsx
@@ -2,10 +2,12 @@ import React from 'react'
 
 import { render, screen } from '@testing-library/react'
 
+import { ApiModel } from '@/api'
+
 import { UserAvatar } from './UserAvatar'
 
 jest.mock('next/link', () => {
-    const Link = ({ href, children, title }: any) => (
+    const Link = ({ href, children, title }: { href: string; children: React.ReactNode; title?: string }) => (
         <a
             href={href}
             title={title}
@@ -18,7 +20,8 @@ jest.mock('next/link', () => {
 })
 
 jest.mock('next/image', () => {
-    const Image = ({ src, alt, width, height }: any) => (
+    const Image = ({ src, alt, width, height }: { src: string; alt: string; width: number; height: number }) => (
+        // eslint-disable-next-line next/no-img-element
         <img
             src={src}
             alt={alt}
@@ -32,18 +35,18 @@ jest.mock('next/image', () => {
 
 jest.mock('next-i18next', () => ({
     useTranslation: () => ({
-        t: (key: string, opts?: any) => opts?.defaultValue ?? key
+        t: (key: string, opts?: { defaultValue?: string }) => opts?.defaultValue ?? key
     })
 }))
 
 // Mock sub-components and utilities
 jest.mock('./AvatarImage', () => ({
-    AvatarImage: ({ user }: any) => <div data-testid={'avatar-image'}>{user?.name}</div>
+    AvatarImage: ({ user }: { user?: ApiModel.User }) => <div data-testid={'avatar-image'}>{user?.name}</div>
 }))
 
 jest.mock('@/public/images/no-avatar.png', () => ({ src: '/no-avatar.png' }), { virtual: true })
 
-const user = { id: 'user-1', name: 'Alice', avatar: '/avatars/alice.jpg' }
+const user: ApiModel.User = { id: 'user-1', name: 'Alice', avatar: '/avatars/alice.jpg' }
 
 describe('UserAvatar', () => {
     describe('without user', () => {
@@ -55,7 +58,7 @@ describe('UserAvatar', () => {
         })
 
         it('renders initials when user has no id', () => {
-            const { container } = render(<UserAvatar user={{ id: '', name: 'No ID' } as any} />)
+            const { container } = render(<UserAvatar user={{ id: '', name: 'No ID' } as ApiModel.User} />)
             const initialsDiv = container.querySelector('.initialsAvatar')
             expect(initialsDiv).toBeInTheDocument()
             expect(initialsDiv).toHaveTextContent('NI')
@@ -64,13 +67,13 @@ describe('UserAvatar', () => {
 
     describe('with user', () => {
         it('renders a link to the user profile', () => {
-            render(<UserAvatar user={user as any} />)
+            render(<UserAvatar user={user} />)
             const link = screen.getByRole('link')
             expect(link).toHaveAttribute('href', '/users/user-1')
         })
 
         it('renders the AvatarImage component', () => {
-            render(<UserAvatar user={user as any} />)
+            render(<UserAvatar user={user} />)
             expect(screen.getByTestId('avatar-image')).toBeInTheDocument()
         })
     })
@@ -79,7 +82,7 @@ describe('UserAvatar', () => {
         it('does not render a link when disableLink is true', () => {
             render(
                 <UserAvatar
-                    user={user as any}
+                    user={user}
                     disableLink
                 />
             )
@@ -91,7 +94,7 @@ describe('UserAvatar', () => {
         it('shows the user name when showName is true', () => {
             render(
                 <UserAvatar
-                    user={user as any}
+                    user={user}
                     showName
                 />
             )
@@ -113,7 +116,7 @@ describe('UserAvatar', () => {
         it('shows a caption when provided', () => {
             render(
                 <UserAvatar
-                    user={user as any}
+                    user={user}
                     showName
                     caption={'Admin'}
                 />

--- a/client/components/shared/users-list/UsersList.test.tsx
+++ b/client/components/shared/users-list/UsersList.test.tsx
@@ -7,7 +7,17 @@ import { ApiModel } from '@/api'
 import { UsersList } from './UsersList'
 
 jest.mock('simple-react-ui-kit', () => ({
-    Container: ({ children, className, title, _footer, _action }: any) => (
+    Container: ({
+        children,
+        className,
+        title
+    }: {
+        children?: React.ReactNode
+        className?: string
+        title?: string
+        _footer?: React.ReactNode
+        _action?: React.ReactNode
+    }) => (
         <div
             className={className}
             data-title={title}
@@ -15,7 +25,7 @@ jest.mock('simple-react-ui-kit', () => ({
             {children}
         </div>
     ),
-    Progress: ({ value, _height, className }: any) => (
+    Progress: ({ value, className }: { value?: number; _height?: number; className?: string }) => (
         <div
             data-testid={'progress'}
             data-value={value}
@@ -25,7 +35,20 @@ jest.mock('simple-react-ui-kit', () => ({
 }))
 
 jest.mock('next/image', () => {
-    const Image = ({ src, alt, width, height, className }: any) => (
+    const Image = ({
+        src,
+        alt,
+        width,
+        height,
+        className
+    }: {
+        src?: string
+        alt?: string
+        width?: number
+        height?: number
+        className?: string
+    }) => (
+        // eslint-disable-next-line next/no-img-element
         <img
             src={src}
             alt={alt}
@@ -54,7 +77,7 @@ jest.mock('@/features/levels/levels.utils', () => ({
 }))
 
 jest.mock('../user-avatar', () => ({
-    UserAvatar: ({ user, showName, caption }: any) => (
+    UserAvatar: ({ user, showName, caption }: { user?: ApiModel.User; showName?: boolean; caption?: string }) => (
         <div data-testid={'user-avatar'}>
             {user?.name}
             {showName && <span data-testid={'user-name-shown'}>{user?.name}</span>}

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "geometki",
-    "version": "1.5.0",
+    "version": "1.5.1",
     "private": true,
     "engines": {
         "node": ">=20.11.0"

--- a/client/utils/address.test.ts
+++ b/client/utils/address.test.ts
@@ -1,4 +1,8 @@
+import { ApiModel } from '@/api'
+
 import { addressToString } from './address'
+
+type PartialAddress = unknown
 
 describe('addressToString', () => {
     it('returns an empty array when location is undefined', () => {
@@ -11,7 +15,7 @@ describe('addressToString', () => {
 
     it('includes country when country.id is set', () => {
         const location = { country: { id: 'ru', name: 'Russia' } }
-        const result = addressToString(location as any)
+        const result = addressToString(location as PartialAddress as ApiModel.Address)
         expect(result).toContainEqual({ id: 'ru', name: 'Russia', type: 'country' })
     })
 
@@ -20,7 +24,7 @@ describe('addressToString', () => {
             country: { id: 'ru', name: 'Russia' },
             locality: { id: 'msk', name: 'Moscow' }
         }
-        const result = addressToString(location as any)
+        const result = addressToString(location as PartialAddress as ApiModel.Address)
         expect(result).toContainEqual({ id: 'msk', name: 'Moscow', type: 'locality' })
     })
 
@@ -29,7 +33,7 @@ describe('addressToString', () => {
             country: { id: 'ru', name: 'Russia' },
             district: { id: 'd1', name: 'Central District' }
         }
-        const result = addressToString(location as any)
+        const result = addressToString(location as PartialAddress as ApiModel.Address)
         expect(result).toContainEqual({ id: 'd1', name: 'Central District', type: 'district' })
     })
 
@@ -38,7 +42,7 @@ describe('addressToString', () => {
             country: { id: 'ru', name: 'Russia' },
             region: { id: 'reg1', name: 'Moscow Oblast' }
         }
-        const result = addressToString(location as any)
+        const result = addressToString(location as PartialAddress as ApiModel.Address)
         expect(result).toContainEqual({ id: 'reg1', name: 'Moscow Oblast', type: 'region' })
     })
 
@@ -47,7 +51,7 @@ describe('addressToString', () => {
             locality: { id: 'loc1', name: 'City' },
             district: { id: 'dist1', name: 'District' }
         }
-        const result = addressToString(location as any)
+        const result = addressToString(location as PartialAddress as ApiModel.Address)
         const types = result.map((item) => item.type)
         expect(types).toContain('locality')
         expect(types).not.toContain('district')
@@ -60,12 +64,12 @@ describe('addressToString', () => {
             district: { id: 'd1', name: 'District' },
             region: { id: 'r1', name: 'Region' }
         }
-        expect(addressToString(location as any).length).toBeLessThanOrEqual(2)
+        expect(addressToString(location as PartialAddress as ApiModel.Address).length).toBeLessThanOrEqual(2)
     })
 
     it('skips country when country.id is absent', () => {
         const location = { country: { name: 'Unknown' }, locality: { id: 'loc1', name: 'City' } }
-        const result = addressToString(location as any)
+        const result = addressToString(location as PartialAddress as ApiModel.Address)
         const types = result.map((item) => item.type)
         expect(types).not.toContain('country')
         expect(types).toContain('locality')

--- a/client/utils/schema.test.ts
+++ b/client/utils/schema.test.ts
@@ -35,12 +35,12 @@ const mockUser: ApiModel.User = {
 describe('PlaceSchema', () => {
     it('returns an object with @context schema.org', () => {
         const schema = PlaceSchema(mockPlace as ApiModel.Place)
-        expect((schema as any)['@context']).toBe('https://schema.org')
+        expect((schema as Record<string, unknown>)['@context']).toBe('https://schema.org')
     })
 
     it('uses LocalBusiness type for museum category', () => {
         const schema = PlaceSchema(mockPlace as ApiModel.Place)
-        expect((schema as any)['@type']).toBe('LocalBusiness')
+        expect((schema as Record<string, unknown>)['@type']).toBe('LocalBusiness')
     })
 
     it('uses TouristAttraction type for non-commercial categories', () => {
@@ -49,94 +49,94 @@ describe('PlaceSchema', () => {
             category: { name: ApiModel.Categories.monument, title: 'Monument' }
         }
         const schema = PlaceSchema(nonCommercialPlace as ApiModel.Place)
-        expect((schema as any)['@type']).toBe('TouristAttraction')
+        expect((schema as Record<string, unknown>)['@type']).toBe('TouristAttraction')
     })
 
     it('uses TouristAttraction type when category is undefined', () => {
         const noCategory = { ...mockPlace, category: undefined }
         const schema = PlaceSchema(noCategory as ApiModel.Place)
         // getPlaceSchemaType(undefined) returns 'LocalBusiness'
-        expect((schema as any)['@type']).toBe('LocalBusiness')
+        expect((schema as Record<string, unknown>)['@type']).toBe('LocalBusiness')
     })
 
     it('includes the place title as name', () => {
-        const schema = PlaceSchema(mockPlace as ApiModel.Place) as any
+        const schema = PlaceSchema(mockPlace as ApiModel.Place) as Record<string, unknown>
         expect(schema.name).toBe('Test Place')
     })
 
     it('includes geo coordinates', () => {
-        const schema = PlaceSchema(mockPlace as ApiModel.Place) as any
-        expect(schema.geo.latitude).toBe(55.75)
-        expect(schema.geo.longitude).toBe(37.62)
+        const schema = PlaceSchema(mockPlace as ApiModel.Place) as Record<string, unknown>
+        expect((schema.geo as Record<string, unknown>).latitude).toBe(55.75)
+        expect((schema.geo as Record<string, unknown>).longitude).toBe(37.62)
     })
 
     it('strips markdown from description', () => {
-        const schema = PlaceSchema(mockPlace as ApiModel.Place) as any
+        const schema = PlaceSchema(mockPlace as ApiModel.Place) as Record<string, unknown>
         // 'removeMarkdown' strips **Bold** → 'Bold content'
         expect(schema.description).toBe('Bold content')
     })
 
     it('includes the canonical URL when provided', () => {
-        const schema = PlaceSchema(mockPlace as ApiModel.Place, 'https://geometki.com/') as any
+        const schema = PlaceSchema(mockPlace as ApiModel.Place, 'https://geometki.com/') as Record<string, unknown>
         expect(schema.url).toBe('https://geometki.com/places/place-1')
     })
 
     it('constructs the cover image URL from IMG_HOST', () => {
-        const schema = PlaceSchema(mockPlace as ApiModel.Place) as any
+        const schema = PlaceSchema(mockPlace as ApiModel.Place) as Record<string, unknown>
         expect(schema.image).toBe('https://cdn.example.com//covers/place-1.jpg')
     })
 
     it('returns undefined for image when cover is not set', () => {
         const noCoverPlace = { ...mockPlace, cover: undefined }
-        const schema = PlaceSchema(noCoverPlace as ApiModel.Place) as any
+        const schema = PlaceSchema(noCoverPlace as ApiModel.Place) as Record<string, unknown>
         expect(schema.image).toBeUndefined()
     })
 
     it('includes view count in interactionStatistic', () => {
-        const schema = PlaceSchema(mockPlace as ApiModel.Place) as any
-        expect(schema.interactionStatistic.userInteractionCount).toBe(50)
+        const schema = PlaceSchema(mockPlace as ApiModel.Place) as Record<string, unknown>
+        expect((schema.interactionStatistic as Record<string, unknown>).userInteractionCount).toBe(50)
     })
 })
 
 describe('UserSchema', () => {
     it('returns an object with @context schema.org', () => {
-        const schema = UserSchema(mockUser) as any
+        const schema = UserSchema(mockUser) as Record<string, unknown>
         expect(schema['@context']).toBe('https://schema.org')
     })
 
     it('returns @type Person', () => {
-        const schema = UserSchema(mockUser) as any
+        const schema = UserSchema(mockUser) as Record<string, unknown>
         expect(schema['@type']).toBe('Person')
     })
 
     it('includes the user id as identifier', () => {
-        const schema = UserSchema(mockUser) as any
+        const schema = UserSchema(mockUser) as Record<string, unknown>
         expect(schema.identifier).toBe('user-1')
     })
 
     it('includes the user name', () => {
-        const schema = UserSchema(mockUser) as any
+        const schema = UserSchema(mockUser) as Record<string, unknown>
         expect(schema.name).toBe('Alice')
     })
 
     it('constructs the avatar image URL from IMG_HOST', () => {
-        const schema = UserSchema(mockUser) as any
+        const schema = UserSchema(mockUser) as Record<string, unknown>
         expect(schema.image).toBe('https://cdn.example.com//avatars/alice.jpg')
     })
 
     it('returns undefined for image when avatar is not set', () => {
         const noAvatarUser = { ...mockUser, avatar: undefined }
-        const schema = UserSchema(noAvatarUser) as any
+        const schema = UserSchema(noAvatarUser) as Record<string, unknown>
         expect(schema.image).toBeUndefined()
     })
 
     it('includes the canonical URL when provided', () => {
-        const schema = UserSchema(mockUser, 'https://geometki.com/') as any
+        const schema = UserSchema(mockUser, 'https://geometki.com/') as Record<string, unknown>
         expect(schema.url).toBe('https://geometki.com/users/user-1')
     })
 
     it('returns undefined for url when canonicalUrl is not provided', () => {
-        const schema = UserSchema(mockUser) as any
+        const schema = UserSchema(mockUser) as Record<string, unknown>
         expect(schema.url).toBeUndefined()
     })
 })


### PR DESCRIPTION
Add CHANGELOG entry for v1.5.1 and bump client package version. Update client unit tests to use ApiModel types and stricter typings (replace many `any` casts with ApiModel.* and Record<string, unknown>), refine jest mocks (next/image, next/link, simple-react-ui-kit, AvatarImage/UserAvatar), and add small test helpers/casts in address and schema tests. These changes improve test type-safety and consistency ahead of the 1.5.1 release.