### PR TITLE
Release v1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 1.6.1
+
+### Patch Changes
+
+- Removed local `Dialog`, `Textarea`, `Dropdown`, and `SearchControl` UI components; replaced all usages with equivalents from `simple-react-ui-kit` (`Dialog`, `TextArea`, `Select`) to reduce duplication and align with the shared component library
+- Refactored `PlaceCoverEditor` and `UserAvatarEditor` to use `Dialog` from `simple-react-ui-kit` with the `title` prop; moved save actions inside dialog content footer instead of using a removed `actions` prop
+- Replaced dialog-based place filters with an inline `PlaceFilterPanel` using `Select` components from `simple-react-ui-kit`; removed Redux overlay toggles and dialog state from the Places page; added debounced location search and responsive horizontal layout
+- Updated comment form to require `Ctrl+Enter` for submission to prevent accidental submits; replaced local `Textarea` with `TextArea` from `simple-react-ui-kit` (`autoResize`, `rows=1`)
+- Refactored achievement tier colors: introduced `--color-tier-bronze`, `--color-tier-silver`, `--color-tier-gold` CSS variables in light and dark themes; replaced inline `style` / `TIER_COLORS` map with SASS `@each`-generated tier modifier classes across `AchievementCard`, `AchievementBadge`, and `AchievementDetailModal`
+- Extracted `AchievementTierBadge` component to centralise tier label rendering with `Badge` from `simple-react-ui-kit`; badge is hidden when tier is `none`; reused in `AchievementCard` and `AchievementDetailModal`
+- Refactored `AchievementDetailModal` to use `Dialog` from `simple-react-ui-kit`; replaced custom overlay and close button logic with library-provided overlay and a custom close icon button
+- Improved notifications: fixed API pagination to replace the first page in full and deduplicate appended pages by `id`; removed `unreadCounter` state and `setUnreadCounter` action from the notification slice; switched `NotificationList` to read unread count from the API cache; `clearNotification` now uses `.unwrap()` with error toast on failure
+- Removed `'use client'` directives from components that do not require them (`AppAuthChecker`, `Logo`, `LoginForm`, `RegistrationForm`, map controls, place sections, and others)
+- Tightened spacing on the Places page container and filter panel for a more compact layout
+- Bumped `simple-react-ui-kit` to `1.8.4` and `@typescript-eslint` packages to `8.59.0`
+
 ## 1.6.0
 
 ### Minor Changes

--- a/client/api/api.ts
+++ b/client/api/api.ts
@@ -238,10 +238,15 @@ export const API = createApi({
         >({
             forceRefetch: ({ currentArg, previousArg }) => currentArg?.offset !== previousArg?.offset,
             merge: (currentCache, newItems, { arg }) => {
-                if ((arg?.offset as number) === 0 && newItems.count === 0 && currentCache.items) {
-                    currentCache.items.length = 0
+                const isFirstPage = (arg?.offset as number) === 0
+
+                if (isFirstPage) {
+                    currentCache.items = newItems.items ?? []
+                    currentCache.count = newItems.count
                 } else {
-                    currentCache.items?.push(...(newItems.items ?? []))
+                    const existingIds = new Set(currentCache.items?.map((i) => i.id))
+                    const fresh = (newItems.items ?? []).filter((i) => !existingIds.has(i.id))
+                    currentCache.items?.push(...fresh)
                 }
             },
             providesTags: ['Notifications'],

--- a/client/app/notificationSlice.test.ts
+++ b/client/app/notificationSlice.test.ts
@@ -3,8 +3,7 @@ import { ApiModel } from '@/api'
 import notificationReducer, {
     deleteAllNotifications,
     deleteNotification,
-    setReadNotification,
-    setUnreadCounter
+    setReadNotification
 } from './notificationSlice'
 
 // addNotification is internal to the slice — access it via the reducer by constructing the action manually
@@ -15,7 +14,6 @@ const addNotification = (notification: ApiModel.Notification) => ({
 
 describe('notificationSlice', () => {
     const initialState = {
-        counter: 0,
         list: [] as ApiModel.Notification[]
     }
 
@@ -23,11 +21,10 @@ describe('notificationSlice', () => {
     const notifB: ApiModel.Notification = { id: 'b', message: 'Second notification', type: 'error' }
 
     describe('initial state', () => {
-        it('has an empty list and zero counter', () => {
+        it('has an empty list', () => {
             const state = notificationReducer(undefined, { type: '@@INIT' })
 
             expect(state.list).toStrictEqual([])
-            expect(state.counter).toBe(0)
         })
     })
 
@@ -99,21 +96,6 @@ describe('notificationSlice', () => {
             const state = notificationReducer(stateWithOne, setReadNotification('nonexistent'))
 
             expect(state.list).toHaveLength(1)
-        })
-    })
-
-    describe('setUnreadCounter', () => {
-        it('sets the counter to the given value', () => {
-            const state = notificationReducer({ ...initialState }, setUnreadCounter(7))
-
-            expect(state.counter).toBe(7)
-        })
-
-        it('resets counter to zero', () => {
-            const stateWithCounter = { ...initialState, counter: 5 }
-            const state = notificationReducer(stateWithCounter, setUnreadCounter(0))
-
-            expect(state.counter).toBe(0)
         })
     })
 })

--- a/client/app/notificationSlice.ts
+++ b/client/app/notificationSlice.ts
@@ -6,7 +6,6 @@ import type { RootState } from './store'
 
 type SnackbarStateProps = {
     list: ApiModel.Notification[]
-    counter: number
 }
 
 export const Notify = createAsyncThunk(
@@ -33,7 +32,6 @@ export const Notify = createAsyncThunk(
 
 const notificationSlice = createSlice({
     initialState: {
-        counter: 0,
         list: []
     } as SnackbarStateProps,
     name: 'snackbar',
@@ -61,14 +59,11 @@ const notificationSlice = createSlice({
                     }
                 ]
             }
-        },
-        setUnreadCounter: (state, { payload }: PayloadAction<number>) => {
-            state.counter = payload
         }
     }
 })
 
-export const { deleteAllNotifications, setReadNotification, deleteNotification, setUnreadCounter, addNotification } =
+export const { deleteAllNotifications, setReadNotification, deleteNotification, addNotification } =
     notificationSlice.actions
 
 export { notificationSlice }

--- a/client/components/layout/app-bar/AppAuthChecker.tsx
+++ b/client/components/layout/app-bar/AppAuthChecker.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import React, { useEffect, useState } from 'react'
 import { getCookie } from 'cookies-next'
 

--- a/client/components/layout/app-bar/Logo.tsx
+++ b/client/components/layout/app-bar/Logo.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import React from 'react'
 import { cn } from 'simple-react-ui-kit'
 

--- a/client/components/layout/app-bar/NotificationList.test.tsx
+++ b/client/components/layout/app-bar/NotificationList.test.tsx
@@ -59,7 +59,8 @@ jest.mock('@/api', () => ({
         useNotificationsDeleteMutation: jest.fn().mockReturnValue([jest.fn(), { isLoading: false, isSuccess: false }]),
         useNotificationsGetListQuery: jest
             .fn()
-            .mockReturnValue({ data: undefined, isLoading: false, isFetching: false })
+            .mockReturnValue({ data: undefined, isLoading: false, isFetching: false }),
+        useNotificationsGetUpdatesQuery: jest.fn().mockReturnValue({ data: undefined })
     }
 }))
 
@@ -116,16 +117,14 @@ describe('NotificationList', () => {
         })
 
         it('does not render the counter when unread count is 0', () => {
-            renderWithStore(<NotificationList />, {
-                notification: { counter: 0, list: [] }
-            })
+            jest.mocked(API.useNotificationsGetUpdatesQuery).mockReturnValue({ data: { count: 0 } })
+            renderWithStore(<NotificationList />)
             expect(screen.queryByTestId('counter')).not.toBeInTheDocument()
         })
 
         it('renders the counter with unread count when counter > 0', () => {
-            renderWithStore(<NotificationList />, {
-                notification: { counter: 3, list: [] }
-            })
+            jest.mocked(API.useNotificationsGetUpdatesQuery).mockReturnValue({ data: { count: 3 } })
+            renderWithStore(<NotificationList />)
             expect(screen.getByTestId('counter')).toHaveTextContent('3')
         })
 

--- a/client/components/layout/app-bar/NotificationList.tsx
+++ b/client/components/layout/app-bar/NotificationList.tsx
@@ -4,7 +4,7 @@ import { Button, Popout, Spinner } from 'simple-react-ui-kit'
 import { useTranslation } from 'next-i18next'
 
 import { API } from '@/api'
-import { deleteAllNotifications, Notify, setUnreadCounter } from '@/app/notificationSlice'
+import { deleteAllNotifications, Notify } from '@/app/notificationSlice'
 import { useAppDispatch, useAppSelector } from '@/app/store'
 import { Counter } from '@/components/ui'
 
@@ -18,12 +18,16 @@ export const NotificationList: React.FC = () => {
 
     const notifyContainerRef = useRef<HTMLDivElement>(null)
 
-    const notifyCounter = useAppSelector((state) => state.notification.counter)
+    const isAuth = useAppSelector((state) => state.auth.isAuth)
 
     const [notifyShow, setNotifyShow] = useState<boolean>(false)
     const [notifyPage, setNotifyPage] = useState<number>(1)
 
     const [clearNotification, { isLoading: loadingClear, isSuccess }] = API.useNotificationsDeleteMutation()
+
+    // Reads from the cache already held by Snackbar — no extra network request
+    const { data: updatesData } = API.useNotificationsGetUpdatesQuery(undefined, { skip: !isAuth })
+    const unreadCount = updatesData?.count ?? 0
 
     const {
         data: notifyData,
@@ -42,9 +46,19 @@ export const NotificationList: React.FC = () => {
     const handleClearNotificationsClick = async () => {
         setNotifyPage(1)
 
-        await clearNotification()
-        dispatch(setUnreadCounter(0))
-        dispatch(deleteAllNotifications())
+        try {
+            await clearNotification().unwrap()
+            dispatch(deleteAllNotifications())
+        } catch {
+            void dispatch(
+                Notify({
+                    id: 'clearNotificationError',
+                    message: t('notification-list-clear-error', { defaultValue: 'Не удалось очистить уведомления' }),
+                    title: '',
+                    type: 'error'
+                })
+            )
+        }
     }
 
     useEffect(() => {
@@ -52,24 +66,13 @@ export const NotificationList: React.FC = () => {
             void dispatch(
                 Notify({
                     id: 'clearNotification',
+                    message: t('notification-list-has-been-cleared', { defaultValue: 'Список уведомлений очищен' }),
                     title: '',
-                    type: 'success',
-                    message: t('notification-list-has-been-cleared', {
-                        defaultValue: 'Список уведомлений очищен'
-                    })
+                    type: 'success'
                 })
             )
         }
-    }, [isSuccess])
-
-    useEffect(() => {
-        const unreadCount = notifyData?.items?.filter(({ read }) => !read).length
-
-        if (unreadCount) {
-            const newUnreadValue = notifyCounter - unreadCount
-            dispatch(setUnreadCounter(newUnreadValue < 0 ? 0 : newUnreadValue))
-        }
-    }, [notifyData])
+    }, [isSuccess, dispatch, t])
 
     useEffect(() => {
         const onScroll = () => {
@@ -87,7 +90,7 @@ export const NotificationList: React.FC = () => {
                 !!notifyData.items?.length &&
                 notifyData.count > notifyData.items.length
             ) {
-                setNotifyPage(notifyPage + 1)
+                setNotifyPage((prev) => prev + 1)
             }
         }
 
@@ -102,21 +105,22 @@ export const NotificationList: React.FC = () => {
         return () => {
             targetDiv.removeEventListener('scroll', onScroll)
         }
-    }, [notifyPage, notifyFetching, notifyData])
+    }, [notifyFetching, notifyData])
 
     return (
         <Popout
             onOpenChange={setNotifyShow}
             trigger={
                 <Button
+                    aria-label={t('notifications', { defaultValue: 'Уведомления' })}
                     mode={'outline'}
                     icon={'Bell'}
                     size={'medium'}
                 >
-                    {notifyCounter > 0 && (
+                    {unreadCount > 0 && (
                         <Counter
                             className={styles.notifyCounter}
-                            value={notifyCounter}
+                            value={unreadCount}
                         />
                     )}
                 </Button>

--- a/client/components/layout/login-form/LoginForm.tsx
+++ b/client/components/layout/login-form/LoginForm.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { Button, Input, Message } from 'simple-react-ui-kit'
 

--- a/client/components/layout/registration-form/RegistrationForm.tsx
+++ b/client/components/layout/registration-form/RegistrationForm.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { Button, Input, Message } from 'simple-react-ui-kit'
 

--- a/client/components/layout/snackbar/Snackbar.tsx
+++ b/client/components/layout/snackbar/Snackbar.tsx
@@ -1,9 +1,7 @@
-'use client'
-
 import React, { useEffect } from 'react'
 
 import { API } from '@/api'
-import { deleteNotification, Notify, setReadNotification, setUnreadCounter } from '@/app/notificationSlice'
+import { deleteNotification, Notify, setReadNotification } from '@/app/notificationSlice'
 import { useAppDispatch, useAppSelector } from '@/app/store'
 
 import { Notification } from './Notification'
@@ -30,8 +28,6 @@ export const Snackbar: React.FC = () => {
         data?.items?.forEach((item) => {
             void dispatch(Notify(item))
         })
-
-        void dispatch(setUnreadCounter(data?.count ?? 0))
     }, [data])
 
     return (

--- a/client/components/map/InteractiveMap.tsx
+++ b/client/components/map/InteractiveMap.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 import * as ReactLeaflet from 'react-leaflet'
 import { LatLngBounds, LatLngExpression, Map, MapOptions } from 'leaflet'

--- a/client/components/map/context-menu/ContextMenu.tsx
+++ b/client/components/map/context-menu/ContextMenu.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import React, { useEffect, useRef, useState } from 'react'
 import { Point } from 'leaflet'
 import { Button, Container } from 'simple-react-ui-kit'

--- a/client/components/map/coordinates-control/CoordinatesControl.tsx
+++ b/client/components/map/coordinates-control/CoordinatesControl.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import React, { useState } from 'react'
 import { Button, Container } from 'simple-react-ui-kit'
 

--- a/client/components/map/heatmap-layer/HeatmapLayer.tsx
+++ b/client/components/map/heatmap-layer/HeatmapLayer.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import React, { useEffect, useRef } from 'react'
 import * as ReactLeaflet from 'react-leaflet'
 import L from 'leaflet'

--- a/client/components/map/historical-photos/HistoricalPhotos.tsx
+++ b/client/components/map/historical-photos/HistoricalPhotos.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import React from 'react'
 import { Marker } from 'react-leaflet'
 import Leaflet from 'leaflet'

--- a/client/components/map/marker-photo-cluster/MarkerPhotoCluster.tsx
+++ b/client/components/map/marker-photo-cluster/MarkerPhotoCluster.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import React from 'react'
 import { Marker } from 'react-leaflet'
 import Leaflet from 'leaflet'

--- a/client/components/map/marker-photo/MarkerPhoto.tsx
+++ b/client/components/map/marker-photo/MarkerPhoto.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import React from 'react'
 import { Marker } from 'react-leaflet'
 import Leaflet from 'leaflet'

--- a/client/components/map/marker-point-cluster/MarkerPointCluster.tsx
+++ b/client/components/map/marker-point-cluster/MarkerPointCluster.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import React from 'react'
 import { Marker } from 'react-leaflet'
 import Leaflet from 'leaflet'

--- a/client/components/map/marker-point/MarkerPoint.tsx
+++ b/client/components/map/marker-point/MarkerPoint.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import React from 'react'
 import { Marker, Popup } from 'react-leaflet'
 import Leaflet from 'leaflet'

--- a/client/components/map/marker-user/MarkerUser.tsx
+++ b/client/components/map/marker-user/MarkerUser.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import React from 'react'
 import { Circle, Marker } from 'react-leaflet'
 import Leaflet from 'leaflet'

--- a/client/components/map/place-mark/PlaceMark.tsx
+++ b/client/components/map/place-mark/PlaceMark.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import React from 'react'
 import { Marker } from 'react-leaflet'
 import Leaflet from 'leaflet'

--- a/client/components/shared/achievement-card/AchievementBadge.tsx
+++ b/client/components/shared/achievement-card/AchievementBadge.tsx
@@ -1,10 +1,9 @@
-import React, { CSSProperties, useState } from 'react'
+import React, { useState } from 'react'
 
 import { useTranslation } from 'next-i18next'
 
 import { ApiType } from '@/api'
 import { AchievementIcon } from '@/components/shared/achievement-icon'
-import { TIER_COLORS } from '@/utils/achievements'
 import { formatDate } from '@/utils/helpers'
 
 import { AchievementDetailModal } from './AchievementDetailModal'
@@ -20,15 +19,10 @@ export const AchievementBadge: React.FC<AchievementBadgeProps> = ({ achievement 
     const [hovered, setHovered] = useState(false)
     const [modalOpen, setModalOpen] = useState(false)
 
-    const tierColor = TIER_COLORS[achievement.tier]
-
-    const cssVars = { '--tier-color': tierColor } as CSSProperties
-
     return (
         <>
             <div
-                className={styles.badgeItem}
-                style={cssVars}
+                className={`${styles.badgeItem} ${styles[`tier--${achievement.tier}`]}`}
                 onMouseEnter={() => setHovered(true)}
                 onMouseLeave={() => setHovered(false)}
                 onClick={() => setModalOpen(true)}

--- a/client/components/shared/achievement-card/AchievementCard.tsx
+++ b/client/components/shared/achievement-card/AchievementCard.tsx
@@ -1,11 +1,11 @@
-import React, { CSSProperties } from 'react'
+import React from 'react'
 import { Icon } from 'simple-react-ui-kit'
 
 import { useTranslation } from 'next-i18next'
 
 import { ApiType } from '@/api'
+import { AchievementTierBadge } from '@/components/shared/achievement-card/AchievementTierBadge'
 import { AchievementIcon } from '@/components/shared/achievement-icon'
-import { TIER_COLORS } from '@/utils/achievements'
 import { formatDate } from '@/utils/helpers'
 
 import styles from './styles.module.sass'
@@ -18,14 +18,9 @@ interface AchievementCardProps {
 export const AchievementCard: React.FC<AchievementCardProps> = ({ achievement, showProgress }) => {
     const { t } = useTranslation()
 
-    const tierColor = TIER_COLORS[achievement.tier]
-
-    const cssVars = { '--tier-color': tierColor } as CSSProperties
-
     return (
         <div
-            className={`${styles.achievementCard} ${achievement.earned_at ? styles.earnedCard : ''}`}
-            style={cssVars}
+            className={`${styles.achievementCard} ${styles[`tier--${achievement.tier}`]} ${achievement.earned_at ? styles.earnedCard : ''}`}
         >
             <div className={styles.cardHeader}>
                 <div className={styles.iconWrapper}>
@@ -38,7 +33,10 @@ export const AchievementCard: React.FC<AchievementCardProps> = ({ achievement, s
                 </div>
                 <div className={styles.cardMeta}>
                     <p className={styles.cardTitle}>{achievement.title}</p>
-                    <span className={styles.tierChip}>{t(`achievements-tier-${achievement.tier}`)}</span>
+                    <AchievementTierBadge
+                        tier={achievement.tier}
+                        t={t}
+                    />
                 </div>
             </div>
 

--- a/client/components/shared/achievement-card/AchievementDetailModal.tsx
+++ b/client/components/shared/achievement-card/AchievementDetailModal.tsx
@@ -1,10 +1,10 @@
-import React, { CSSProperties } from 'react'
+import React from 'react'
 import { TFunction } from 'i18next'
-import { Icon } from 'simple-react-ui-kit'
+import { Dialog, Icon } from 'simple-react-ui-kit'
 
 import { ApiType } from '@/api'
+import { AchievementTierBadge } from '@/components/shared/achievement-card/AchievementTierBadge'
 import { AchievementIcon } from '@/components/shared/achievement-icon'
-import { TIER_COLORS } from '@/utils/achievements'
 import { formatDate } from '@/utils/helpers'
 
 import styles from './styles.module.sass'
@@ -16,67 +16,54 @@ interface AchievementDetailModalProps {
     t: TFunction
 }
 
-export const AchievementDetailModal: React.FC<AchievementDetailModalProps> = ({ achievement, open, onClose, t }) => {
-    if (!open) {
-        return null
-    }
-
-    const tierColor = TIER_COLORS[achievement.tier]
-    const cssVars = { '--tier-color': tierColor } as CSSProperties
-
-    return (
-        <div
-            className={styles.overlay}
+export const AchievementDetailModal: React.FC<AchievementDetailModalProps> = ({ achievement, open, onClose, t }) => (
+    <Dialog
+        open={open}
+        maxWidth={'420px'}
+        showOverlay={true}
+        contentClassName={styles[`modalContent--${achievement.tier}`]}
+        onCloseDialog={onClose}
+    >
+        <button
+            className={styles.closeBtn}
             onClick={onClose}
-            role={'presentation'}
+            aria-label={t('cancel')}
         >
-            <div
-                className={styles.modal}
-                style={cssVars}
-                onClick={(e) => e.stopPropagation()}
-                role={'dialog'}
-                aria-modal={'true'}
-                aria-label={achievement.title}
-            >
-                <button
-                    className={styles.closeBtn}
-                    onClick={onClose}
-                    aria-label={t('cancel')}
-                >
-                    <Icon name={'Close'} />
-                </button>
+            <Icon name={'Close'} />
+        </button>
 
-                <div className={styles.modalHeader}>
-                    <div className={styles.iconWrapper}>
-                        <AchievementIcon
-                            image={achievement.image}
-                            icon={achievement.icon}
-                            alt={achievement.title}
-                            size={36}
-                        />
-                    </div>
-                    <div>
-                        <h2 className={styles.modalTitle}>{achievement.title}</h2>
-                        <span className={styles.tierChip}>{t(`achievements-tier-${achievement.tier}`)}</span>
-                    </div>
-                </div>
-
-                {achievement.description && <p className={styles.modalDescription}>{achievement.description}</p>}
-
-                {achievement.earned_at && (
-                    <p className={styles.modalMeta}>
-                        {t('achievements-earned-at', {
-                            date: formatDate(achievement.earned_at, 'D MMMM YYYY')
-                        })}
-                    </p>
-                )}
-
-                {achievement.xp_bonus > 0 && (
-                    <p className={styles.modalMeta}>
-                        {t('achievements-xp-bonus')}: <strong>+{achievement.xp_bonus} XP</strong>
-                    </p>
-                )}
+        <div className={styles.modalHeader}>
+            <div className={styles.iconWrapper}>
+                <AchievementIcon
+                    image={achievement.image}
+                    icon={achievement.icon}
+                    alt={achievement.title}
+                    size={36}
+                />
+            </div>
+            <div>
+                <h2 className={styles.modalTitle}>{achievement.title}</h2>
+                <AchievementTierBadge
+                    tier={achievement.tier}
+                    t={t}
+                />
             </div>
         </div>
-    )
-}
+
+        {achievement.description && <p className={styles.modalDescription}>{achievement.description}</p>}
+
+        {achievement.earned_at && (
+            <p className={styles.modalMeta}>
+                {t('achievements-earned-at', {
+                    date: formatDate(achievement.earned_at, 'D MMMM YYYY')
+                })}
+            </p>
+        )}
+
+        {achievement.xp_bonus > 0 && (
+            <p className={styles.modalMeta}>
+                {t('achievements-xp-bonus')}: <strong>+{achievement.xp_bonus} XP</strong>
+            </p>
+        )}
+    </Dialog>
+)

--- a/client/components/shared/achievement-card/AchievementTierBadge.tsx
+++ b/client/components/shared/achievement-card/AchievementTierBadge.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import { TFunction } from 'i18next'
+import { Badge } from 'simple-react-ui-kit'
+
+import { ApiType } from '@/api'
+
+import styles from './styles.module.sass'
+
+interface AchievementTierBadgeProps {
+    tier: ApiType.Achievements.AchievementTier
+    t: TFunction
+}
+
+export const AchievementTierBadge: React.FC<AchievementTierBadgeProps> = ({ tier, t }) => {
+    if (tier === 'none') {
+        return null
+    }
+
+    return (
+        <Badge
+            size={'small'}
+            className={styles.tierChip}
+            label={t(`achievements-tier-${tier}`)}
+        />
+    )
+}

--- a/client/components/shared/achievement-card/styles.module.sass
+++ b/client/components/shared/achievement-card/styles.module.sass
@@ -19,7 +19,21 @@
             left: 0
             right: 0
             height: 3px
-            background: var(--tier-color)
+
+    @each $tier in bronze, silver, gold
+        &.tier--#{$tier}
+            &.earnedCard::before
+                background: var(--color-tier-#{$tier})
+
+            .iconWrapper svg
+                color: var(--color-tier-#{$tier})
+
+            .tierChip
+                background: color-mix(in srgb, var(--color-tier-#{$tier}) 15%, transparent) !important
+                color: var(--color-tier-#{$tier}) !important
+
+            .progressFill
+                background: var(--color-tier-#{$tier})
 
 .cardHeader
     display: flex
@@ -39,7 +53,6 @@
     svg
         width: 22px
         height: 22px
-        color: var(--tier-color)
 
 .cardMeta
     flex: 1
@@ -55,15 +68,9 @@
     text-overflow: ellipsis
 
 .tierChip
-    display: inline-flex
-    align-items: center
-    gap: 4px
     font-size: variables.$fontSizeCaption
     font-weight: 500
-    padding: 2px 8px
     border-radius: 10px
-    background: color-mix(in srgb, var(--tier-color) 15%, transparent)
-    color: var(--tier-color)
 
 .cardDescription
     font-size: variables.$fontSizeParagraph
@@ -91,7 +98,6 @@
 .progressFill
     height: 100%
     border-radius: 3px
-    background: var(--tier-color)
     transition: width 0.3s ease
 
 .earnedBadge
@@ -141,6 +147,14 @@
     position: relative
     cursor: pointer
 
+    @each $tier in bronze, silver, gold
+        &.tier--#{$tier}
+            .badgeIcon
+                border-color: var(--color-tier-#{$tier})
+
+                svg
+                    color: var(--color-tier-#{$tier})
+
 .badgeIcon
     width: 48px
     height: 48px
@@ -149,7 +163,7 @@
     display: flex
     align-items: center
     justify-content: center
-    border: 3px solid var(--tier-color)
+    border: 3px solid transparent
     transition: transform 0.15s ease
 
     &:hover
@@ -158,7 +172,6 @@
     svg
         width: 24px
         height: 24px
-        color: var(--tier-color)
 
 .badgeTooltip
     position: absolute
@@ -255,29 +268,6 @@
         opacity: 0.4
 
 // Achievement detail modal
-.overlay
-    position: fixed
-    inset: 0
-    background: rgba(0, 0, 0, 0.5)
-    z-index: 500
-    display: flex
-    align-items: center
-    justify-content: center
-    padding: 16px
-
-.modal
-    position: relative
-    background: var(--modal-background)
-    border-radius: var(--border-radius)
-    box-shadow: variables.$boxShadow5
-    width: 100%
-    max-width: 420px
-    padding: 24px
-    border-top: 4px solid var(--tier-color)
-
-    @media only screen and (max-width: variables.$mobileMaxWidth)
-        max-width: 96%
-
 .closeBtn
     position: absolute
     top: 12px
@@ -297,6 +287,15 @@
         width: 20px
         height: 20px
 
+.modalContent
+    @each $tier in bronze, silver, gold
+        &--#{$tier}
+            border-top: 4px solid var(--color-tier-#{$tier})
+
+            .tierChip
+                background: color-mix(in srgb, var(--color-tier-#{$tier}) 15%, transparent) !important
+                color: var(--color-tier-#{$tier}) !important
+
 .modalHeader
     display: flex
     align-items: center
@@ -304,7 +303,7 @@
     margin-bottom: 16px
 
 .modalTitle
-    margin: 0 0 6px
+    margin: 0
     font-size: variables.$fontSizeTitleH1
     color: var(--text-color-primary)
 

--- a/client/components/ui/content-editor/ContentEditor.tsx
+++ b/client/components/ui/content-editor/ContentEditor.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import React from 'react'
 import { cn, Spinner } from 'simple-react-ui-kit'
 

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "geometki",
-    "version": "1.6.0",
+    "version": "1.6.1",
     "private": true,
     "engines": {
         "node": ">=20.11.0"
@@ -49,7 +49,7 @@
         "remove": "^0.1.5",
         "schema-dts": "^1.1.5",
         "sharp": "^0.34.5",
-        "simple-react-ui-kit": "^1.8.4",
+        "simple-react-ui-kit": "^1.8.5",
         "yet-another-react-lightbox": "^3.31.0"
     },
     "devDependencies": {

--- a/client/sections/place/place-share-buttons/PlaceShareButtons.tsx
+++ b/client/sections/place/place-share-buttons/PlaceShareButtons.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import React, { useEffect, useState } from 'react'
 import {
     OKIcon,

--- a/client/styles/dark.css
+++ b/client/styles/dark.css
@@ -139,4 +139,10 @@
 
     /* Skeleton */
     --skeleton-background-animation: linear-gradient( 90deg, transparent, rgba(255, 255, 255, 0.05), transparent);
+
+    /* Achievement tiers */
+    --color-tier-bronze: #cd7f32;
+    --color-tier-silver: #c0c0c0;
+    --color-tier-gold: #ffd700;
+    --color-tier-none: var(--icon-color-secondary);
 }

--- a/client/styles/light.css
+++ b/client/styles/light.css
@@ -130,4 +130,10 @@
 
     /* Skeleton */
     --skeleton-background-animation: linear-gradient( 90deg, transparent, rgba(0, 0, 0, 0.04), transparent);
+
+    /* Achievement tiers */
+    --color-tier-bronze: #cd7f32;
+    --color-tier-silver: #c0c0c0;
+    --color-tier-gold: #ffd700;
+    --color-tier-none: var(--icon-color-secondary);
 }

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -6152,7 +6152,7 @@ __metadata:
     sass: "npm:^1.99.0"
     schema-dts: "npm:^1.1.5"
     sharp: "npm:^0.34.5"
-    simple-react-ui-kit: "npm:^1.8.4"
+    simple-react-ui-kit: "npm:^1.8.5"
     ts-node: "npm:^10.9.2"
     typescript: "npm:5.9.3"
     typescript-eslint: "npm:^8.59.0"
@@ -10983,15 +10983,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"simple-react-ui-kit@npm:^1.8.4":
-  version: 1.8.4
-  resolution: "simple-react-ui-kit@npm:1.8.4"
+"simple-react-ui-kit@npm:^1.8.5":
+  version: 1.8.5
+  resolution: "simple-react-ui-kit@npm:1.8.5"
   dependencies:
     dayjs: "npm:^1.11.20"
     lodash-es: "npm:^4.18.1"
     react: "npm:^19.2.5"
     react-dom: "npm:^19.2.5"
-  checksum: 10c0/2dfafe83d5ae73a85d47f3e04d4b37e32c1553e858177d33b2dc7358b76f9a2e7b2e5186a9dd9ed5461151e5d07edb5b86d466572763adec6a86737b16d8e09f
+  checksum: 10c0/b1f52bdc00c406550e610d3540c8991aef5e32c4ede889b93e8a1e1bff3ae4b62f79070c4065292c0f8dde6c8e2f42513e1a20b06f4e61a4310351daa1f54f85
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Patch Changes

- Removed local `Dialog`, `Textarea`, `Dropdown`, and `SearchControl` UI components; replaced all usages with equivalents from `simple-react-ui-kit` (`Dialog`, `TextArea`, `Select`) to reduce duplication and align with the shared component library
- Refactored `PlaceCoverEditor` and `UserAvatarEditor` to use `Dialog` from `simple-react-ui-kit` with the `title` prop; moved save actions inside dialog content footer instead of using a removed `actions` prop
- Replaced dialog-based place filters with an inline `PlaceFilterPanel` using `Select` components from `simple-react-ui-kit`; removed Redux overlay toggles and dialog state from the Places page; added debounced location search and responsive horizontal layout
- Updated comment form to require `Ctrl+Enter` for submission to prevent accidental submits; replaced local `Textarea` with `TextArea` from `simple-react-ui-kit` (`autoResize`, `rows=1`)
- Refactored achievement tier colors: introduced `--color-tier-bronze`, `--color-tier-silver`, `--color-tier-gold` CSS variables in light and dark themes; replaced inline `style` / `TIER_COLORS` map with SASS `@each`-generated tier modifier classes across `AchievementCard`, `AchievementBadge`, and `AchievementDetailModal`
- Extracted `AchievementTierBadge` component to centralise tier label rendering with `Badge` from `simple-react-ui-kit`; badge is hidden when tier is `none`; reused in `AchievementCard` and `AchievementDetailModal`
- Refactored `AchievementDetailModal` to use `Dialog` from `simple-react-ui-kit`; replaced custom overlay and close button logic with library-provided overlay and a custom close icon button
- Improved notifications: fixed API pagination to replace the first page in full and deduplicate appended pages by `id`; removed `unreadCounter` state and `setUnreadCounter` action from the notification slice; switched `NotificationList` to read unread count from the API cache; `clearNotification` now uses `.unwrap()` with error toast on failure
- Removed `'use client'` directives from components that do not require them (`AppAuthChecker`, `Logo`, `LoginForm`, `RegistrationForm`, map controls, place sections, and others)
- Tightened spacing on the Places page container and filter panel for a more compact layout
- Bumped `simple-react-ui-kit` to `1.8.4` and `@typescript-eslint` packages to `8.59.0`