### PR TITLE
Add 10px padding to tags grid

### DIFF
--- a/client/sections/tags/tags-grid/styles.module.sass
+++ b/client/sections/tags/tags-grid/styles.module.sass
@@ -1,7 +1,7 @@
 @use '../../../styles/variables' as variables
 
 .tagsGrid
-    padding: 0
+    padding: 10px
 
 .anchor
     position: absolute


### PR DESCRIPTION
Change .tagsGrid padding from 0 to 10px in client/sections/tags/tags-grid/styles.module.sass to provide consistent spacing around the tags grid.