### PR TITLE
Release 1.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 1.6.5
+
+### Patch Changes
+
+- Activity feed: improved pagination and grouping — Fetch N+1 items as a lookahead and drop the extra to enforce the requested limit. Added recursion depth limit to `addNextActivityItems`. Grouping now compares timestamps (≤600 s) and requires matching `place_id`/`user_id`. Group type priority refined: `place > edit > cover > photo`. Server ordering changed to `created_at DESC, type DESC`; `cover` activity type re-enabled; `rating.value` and `comments.content` joined and selected.
+- Activity feed: cover label and scroll cursor fix — Added translation mapping for `ActivityTypes.Cover`. Refactored `IndexPage` scroll handler to derive `cursorDate` from the last item's `created.date`, replacing the previous `items.length` guard. `onScroll` dependencies updated to `[data, isFetching]`.
+- Activity feed: scoped cache keys per author/place — `serializeQueryArgs` now namespaces cache keys with endpoint and `author`/`place` (e.g. `endpoint_author_<id>`) to prevent collisions and ensure correct per-query caching. `Cover` activity type re-enabled in `ActivityTypes`.
+- Places model: expose `visit_radius_m` and `verification_exempt` — Both fields added to the `SELECT` clause in `PlacesModel` so they are returned by place queries and available for distance calculations and verification logic.
+- Entity normalization: casts, dates, formatting — Standardized `$dates`, `$casts`, and array formatting across `UserAchievementEntity`, `UserBookmarkEntity`, `UserEntity`, `UserLevelEntity`, `UserNotificationEntity`, and `UserVisitedPlaceEntity`. Added `earned_at` and `visited_at` to relevant `$dates`; `read` cast changed to `boolean`.
+- Entity formatting: `RatingEntity` `created` cast — Added `'created' => 'datetime'` cast to `RatingEntity`. Applied consistent formatting (trailing commas, datamap cleanup) across entity classes.
+- Entity formatting: `OverpassCategory` explicit attributes and casts — Added `$attributes` and `$casts` to `OverpassCategory` so properties are properly typed. Removed commented-out `$dates` from `CategoryEntity`. Normalized array formatting across multiple entity classes.
+- Places: avatar resolution for visited users — `AvatarLibrary` instantiated in the visited-users query; returned records now map raw `avatar` values to resolved paths via `buildPath('small')`.
+- API: normalize place fields to camelCase — Renamed `visit_radius_m` → `visitRadiusM` and `verification_exempt` → `verificationExempt` in API responses. Server controller maps DB snake_case to camelCase and strips the originals; client models updated accordingly.
+- Notifications: centralized localization and simplified meta — Server now reads the request locale and builds a simplified `meta` object (`title`, `level`/`image`) for `achievements` and `level` notifications. Client API model updated; notification UI simplified to use `meta.title`, removing locale-dependent rendering.
+- Notifications and places: payload trimming and formatter extension — Removed unused fields from the `achievements` notification payload (only `title_en`, `title_ru`, `image` retained). `PlaceFormatterLibrary` extended to include `visit_radius_m` and `verification_exempt` in formatted place rows.
+
 ## 1.6.4
 
 ### Patch Changes

--- a/client/api/api.ts
+++ b/client/api/api.ts
@@ -123,7 +123,15 @@ export const API = createApi({
             },
             providesTags: (result, error, arg) => [{ id: arg?.author || arg?.place || 'LIST', type: 'Activity' }],
             query: (params) => `activity${encodeQueryData(params)}`,
-            serializeQueryArgs: ({ endpointName, queryArgs }) => queryArgs?.author || queryArgs?.place || endpointName
+            serializeQueryArgs: ({ endpointName, queryArgs }) => {
+                if (queryArgs?.author) {
+                    return `${endpointName}_author_${queryArgs.author}`
+                }
+                if (queryArgs?.place) {
+                    return `${endpointName}_place_${queryArgs.place}`
+                }
+                return endpointName
+            }
         }),
         activityGetList: builder.query<ApiType.Activity.GetListResponse, Maybe<ApiType.Activity.GetListRequest>>({
             providesTags: (result, error, arg) => [{ id: arg?.place || arg?.author, type: 'Activity' }],

--- a/client/api/models/activity.ts
+++ b/client/api/models/activity.ts
@@ -19,7 +19,7 @@ export type Activity = {
 
 export const ActivityTypes = {
     Comment: 'comment',
-    // Cover: 'cover',
+    Cover: 'cover',
     Edit: 'edit',
     Photo: 'photo',
     Place: 'place',

--- a/client/api/models/notification.ts
+++ b/client/api/models/notification.ts
@@ -1,7 +1,6 @@
 import { ActivityType, DateTime } from '@/api/types'
 
 import { Place } from './place'
-import { UserLevel } from './userLevel'
 
 export type Notification = {
     id: string
@@ -9,17 +8,11 @@ export type Notification = {
     message?: string
     read?: boolean
     type?: ActivityType | 'achievements'
-    meta?: UserLevel & {
+    meta?: {
         value?: number
-        achievement_id?: string
-        group_slug?: string
-        tier?: string
-        title_en?: string
-        title_ru?: string
-        icon?: string
+        title?: string
+        level?: number
         image?: string
-        xp_bonus?: number
-        is_upgrade?: boolean
     }
     activity?: ActivityType
     place?: Pick<Place, 'id' | 'title' | 'cover'>

--- a/client/api/models/place.ts
+++ b/client/api/models/place.ts
@@ -28,6 +28,6 @@ export type Place = {
         full: string
         preview: string
     }
-    visit_radius_m?: number
-    verification_exempt?: boolean
+    visitRadiusM?: number
+    verificationExempt?: boolean
 }

--- a/client/components/layout/snackbar/Notification.tsx
+++ b/client/components/layout/snackbar/Notification.tsx
@@ -2,7 +2,6 @@ import React, { useEffect } from 'react'
 import { cn, Icon } from 'simple-react-ui-kit'
 
 import Link from 'next/link'
-import { useRouter } from 'next/router'
 import { useTranslation } from 'next-i18next/pages'
 
 import { ApiModel } from '@/api'
@@ -20,7 +19,6 @@ interface NotificationProps extends ApiModel.Notification {
 
 export const Notification: React.FC<NotificationProps> = ({ showDate, onClose, onLoad, ...props }) => {
     const { t } = useTranslation()
-    const { locale } = useRouter()
 
     useEffect(() => {
         onLoad?.(props.id)
@@ -57,11 +55,7 @@ export const Notification: React.FC<NotificationProps> = ({ showDate, onClose, o
                     ) : props.type === 'level' ? (
                         `${props.meta?.title} (${props.meta?.level})`
                     ) : props.type === 'achievements' ? (
-                        <span>
-                            {locale === 'en'
-                                ? (props.meta?.title_en ?? '')
-                                : (props.meta?.title_ru ?? props.meta?.title_en ?? '')}
-                        </span>
+                        <span>{props.meta?.title ?? ''}</span>
                     ) : props.place ? (
                         <Link
                             href={`/places/${props.place.id}`}

--- a/client/components/shared/activity-list/ActivityListItem.tsx
+++ b/client/components/shared/activity-list/ActivityListItem.tsx
@@ -53,6 +53,9 @@ export const ActivityListItem: React.FC<ActivityListItemProps> = ({ item, title 
                                 [ApiModel.ActivityTypes.Comment]: t('activity-comment', {
                                     defaultValue: 'Комментировал(а) интересное место'
                                 }),
+                                [ApiModel.ActivityTypes.Cover]: t('activity-cover', {
+                                    defaultValue: 'Обновил(а) обложку интересного места'
+                                }),
                                 [ApiModel.ActivityTypes.Edit]: t('activity-editing', {
                                     defaultValue: 'Редактировал(а) интересное место'
                                 }),

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "geometki",
-    "version": "1.6.4",
+    "version": "1.6.5",
     "private": true,
     "engines": {
         "node": ">=20.11.0"

--- a/client/pages/index.tsx
+++ b/client/pages/index.tsx
@@ -34,11 +34,12 @@ const IndexPage: NextPage<IndexPageProps> = ({ placesList, usersList }) => {
 
     const onScroll = useCallback(() => {
         const scrolledToBottom = window.innerHeight + window.scrollY >= document.body.offsetHeight - 20
+        const cursorDate = data?.items[data.items.length - 1]?.created?.date
 
-        if (scrolledToBottom && !isFetching && !!data?.items.length) {
-            setLastDate(data.items[data.items.length - 1].created?.date)
+        if (scrolledToBottom && !isFetching && cursorDate) {
+            setLastDate(cursorDate)
         }
-    }, [isFetching, data])
+    }, [data, isFetching])
 
     useEffect(() => {
         document.addEventListener('scroll', onScroll)

--- a/client/pages/places/[id]/index.tsx
+++ b/client/pages/places/[id]/index.tsx
@@ -209,7 +209,7 @@ const PlacePage: NextPage<PlacePageProps> = ({ ratingCount, place, photoList, ne
             <PlaceShareButtons
                 placeId={place?.id}
                 placeUrl={pagePlaceUrl}
-                verificationExempt={place?.verification_exempt}
+                verificationExempt={place?.verificationExempt}
             />
 
             <PlaceVisited place={place} />

--- a/server/app/Controllers/Activity.php
+++ b/server/app/Controllers/Activity.php
@@ -45,7 +45,12 @@ class Activity extends ResourceController
         $place    = $this->request->getGet('place', FILTER_SANITIZE_SPECIAL_CHARS);
 
         $placeContent  = new PlacesContent();
-        $activityData  = $this->model->getActivityList($lastDate, $author, $place, min($limit, 40), $offset);
+        $activityData  = $this->model->getActivityList($lastDate, $author, $place, min($limit + 1, 40), $offset);
+
+        // Drop the extra lookahead row so we return at most $limit items
+        if (count($activityData) > $limit) {
+            array_pop($activityData);
+        }
 
         $placesIds   = [];
         $activityIds = [];
@@ -66,10 +71,6 @@ class Activity extends ResourceController
         // Now we group the data
         $groupedData = $this->groupSimilarActivities($activityData, $placeContent);
 
-        // Remove the last object in the array if it may not be fully grouped
-        if (count($groupedData) >= $limit) {
-            array_pop($groupedData);
-        }
 
         // Increasing the view counter
         if (!empty($activityIds)) {
@@ -86,9 +87,9 @@ class Activity extends ResourceController
      *
      * @return void
      */
-    protected function addNextActivityItems(array &$activityData): void
+    protected function addNextActivityItems(array &$activityData, int $depth = 0): void
     {
-        if (empty($activityData)) {
+        if (empty($activityData) || $depth >= 5) {
             return;
         }
 
@@ -105,6 +106,8 @@ class Activity extends ResourceController
         }
 
         foreach ($nextItems as $nextItem) {
+            $lastItem = end($activityData);
+
             if ($this->shouldGroupActivities($lastItem, $nextItem)) {
                 $activityData[] = $nextItem;
             } else {
@@ -113,7 +116,7 @@ class Activity extends ResourceController
         }
 
         // Recursively call the function to add the following elements
-        $this->addNextActivityItems($activityData);
+        $this->addNextActivityItems($activityData, $depth + 1);
     }
 
     /**
@@ -126,10 +129,12 @@ class Activity extends ResourceController
      */
     private function shouldGroupActivities(object $lastItem, object $nextItem): bool
     {
+        $timeDiff = abs($lastItem->created_at->getTimestamp() - $nextItem->created_at->getTimestamp());
+
         return (
-            (!isset($lastItem->place) || $lastItem->place->id === $nextItem->place_id) &&
-            $lastItem->user_id === $nextItem->user_id
-            // (strtotime($lastItem->created) - strtotime($nextItem->created_at)) <= 60 * 60
+            $lastItem->user_id === $nextItem->user_id &&
+            $lastItem->place_id === $nextItem->place_id &&
+            $timeDiff <= 600
         );
     }
 
@@ -155,10 +160,11 @@ class Activity extends ResourceController
             return $groupData;
         }
 
-        $avatarLibrary  = new AvatarLibrary();
-        $lastGroupIndex = -1;
+        $avatarLibrary   = new AvatarLibrary();
+        $lastGroupIndex  = -1;
+        $groupCreatedTs  = [];
         foreach ($activityData as $item) {
-            // $itemCreatedAt = strtotime($item->created_at);
+            $itemCreatedAt = $item->created_at->getTimestamp();
             $photoPath = PATH_PHOTOS . $item->place_id . '/';
             $itemPhoto = $item->type === 'photo' && $item->filename ? [
                 'full'      => $photoPath . $item->filename . '.' . $item->extension,
@@ -172,19 +178,22 @@ class Activity extends ResourceController
             if (
                 $lastGroupIndex !== -1 &&
                 (!isset($groupData[$lastGroupIndex]->place) || $groupData[$lastGroupIndex]->place->id === $item->place_id) &&
-                isset($groupData[$lastGroupIndex]->author) && $groupData[$lastGroupIndex]->author?->id === $item?->user_id
-                // ($itemCreatedAt - strtotime($groupData[$lastGroupIndex]->created)) <= 60 * 60
+                isset($groupData[$lastGroupIndex]->author) && $groupData[$lastGroupIndex]->author?->id === $item?->user_id &&
+                abs($itemCreatedAt - $groupCreatedTs[$lastGroupIndex]) <= 600
             ) {
                 // We are updating the group date to an earlier one.
-                if (strtotime($item->created_at) < strtotime($groupData[$lastGroupIndex]->created)) {
+                if ($itemCreatedAt < $groupCreatedTs[$lastGroupIndex]) {
                     $groupData[$lastGroupIndex]->created = $item->created_at;
+                    $groupCreatedTs[$lastGroupIndex]     = $itemCreatedAt;
                 }
 
-                // Determine the group type based on priority
+                // Determine the group type based on priority: place > edit > cover > photo
                 if ($item->type === 'place') {
                     $groupData[$lastGroupIndex]->type = 'place';
                 } elseif ($item->type === 'edit' && $groupData[$lastGroupIndex]->type !== 'place') {
                     $groupData[$lastGroupIndex]->type = 'edit';
+                } elseif ($item->type === 'cover' && !in_array($groupData[$lastGroupIndex]->type, ['place', 'edit'])) {
+                    $groupData[$lastGroupIndex]->type = 'cover';
                 } elseif ($item->type === 'photo' && $groupData[$lastGroupIndex]->type === 'photo') {
                     $groupData[$lastGroupIndex]->type = 'photo';
                 }
@@ -245,8 +254,9 @@ class Activity extends ResourceController
                 ];
             }
 
-            $groupData[]    = $currentGroup;
-            $lastGroupIndex = array_key_last($groupData);
+            $groupData[]                          = $currentGroup;
+            $lastGroupIndex                       = array_key_last($groupData);
+            $groupCreatedTs[$lastGroupIndex]      = $itemCreatedAt;
         }
 
         return array_values($groupData);

--- a/server/app/Controllers/Notifications.php
+++ b/server/app/Controllers/Notifications.php
@@ -137,6 +137,7 @@ class Notifications extends ResourceController
             return [];
         }
 
+        $locale       = $this->request->getLocale();
         $placeContent = new PlacesContent(350);
         $placesData = [];
         $placesIds  = [];
@@ -165,11 +166,26 @@ class Notifications extends ResourceController
 
             $findPlace = array_search($notify->place_id, array_column($placesData, 'id'));
             $placeData = $findPlace !== false ? $placesData[$findPlace] : null;
+            $meta = $notify->meta;
+            if ($meta) {
+                if ($notify->type === 'achievements') {
+                    $meta = [
+                        'title' => $locale === 'en' ? ($meta->title_en ?? '') : ($meta->title_ru ?? $meta->title_en ?? ''),
+                        'image' => $meta->image ?? null,
+                    ];
+                } elseif ($notify->type === 'level') {
+                    $meta = [
+                        'title' => $locale === 'en' ? ($meta->title_en ?? '') : ($meta->title_ru ?? $meta->title_en ?? ''),
+                        'level' => $meta->level ?? null,
+                    ];
+                }
+            }
+
             $tempData  = [
                 'id'       => $notify->id,
                 'type'     => $notify->type,
                 'activity' => $notify->activity_type,
-                'meta'     => $notify->meta
+                'meta'     => $meta
             ];
 
             if (isset($notify->created_at)) {

--- a/server/app/Controllers/Places.php
+++ b/server/app/Controllers/Places.php
@@ -200,6 +200,9 @@ class Places extends ResourceController
                 $place->cover = $cover;
             }
 
+            $place->visitRadiusM       = (int) $place->visit_radius_m;
+            $place->verificationExempt = (bool) $place->verification_exempt;
+
             $formatter->cleanupFields($place);
         }
 
@@ -292,6 +295,9 @@ class Places extends ResourceController
         $placeData->title   = $placeContent->title($id);
         $placeData->content = $placeContent->content($id);
 
+        $placeData->visitRadiusM       = (int) $placeData->visit_radius_m;
+        $placeData->verificationExempt = (bool) $placeData->verification_exempt;
+
         unset($placeData->user_id, $placeData->user_name, $placeData->user_avatar, $placeData->activity_at,
             $placeData->country_id, $placeData->region_id, $placeData->district_id, $placeData->locality_id,
             $placeData->address_en, $placeData->address_ru,
@@ -300,6 +306,7 @@ class Places extends ResourceController
             $placeData->district_en, $placeData->district_ru,
             $placeData->city_en, $placeData->city_ru,
             $placeData->category_en, $placeData->category_ru,
+            $placeData->visit_radius_m, $placeData->verification_exempt,
         );
 
         // Incrementing view counter + daily log (atomic) + optional per-user tracking

--- a/server/app/Controllers/Visited.php
+++ b/server/app/Controllers/Visited.php
@@ -2,6 +2,7 @@
 
 namespace App\Controllers;
 
+use App\Libraries\AvatarLibrary;
 use App\Libraries\SessionLibrary;
 use App\Models\PlacesModel;
 use App\Models\UsersVisitedPlacesModel;
@@ -70,11 +71,18 @@ class Visited extends ResourceController
     {
         $visitedModel = new UsersVisitedPlacesModel();
 
+        $avatarLibrary = new AvatarLibrary();
+
         $items = $visitedModel
             ->select('users.id, users.name, users.avatar')
             ->join('users', 'users_visited_places.user_id = users.id', 'inner')
             ->where(['place_id' => $id])
             ->findAll();
+
+        $items = array_map(function ($item) use ($avatarLibrary) {
+            $item->avatar = $avatarLibrary->buildPath($item->id, $item->avatar, 'small');
+            return $item;
+        }, $items);
 
         $verifiedCount = $visitedModel
             ->where(['place_id' => $id, 'verified' => 1])

--- a/server/app/Entities/AchievementEntity.php
+++ b/server/app/Entities/AchievementEntity.php
@@ -4,8 +4,7 @@ namespace App\Entities;
 
 use CodeIgniter\Entity\Entity;
 
-class AchievementEntity extends Entity
-{
+class AchievementEntity extends Entity {
     protected $attributes = [
         'id'             => null,
         'group_slug'     => null,

--- a/server/app/Entities/ActivityEntity.php
+++ b/server/app/Entities/ActivityEntity.php
@@ -19,7 +19,7 @@ class ActivityEntity extends Entity {
     protected $dates = [
         'created_at',
         'updated_at',
-        'deleted_at'
+        'deleted_at',
     ];
 
     protected $casts = [
@@ -30,6 +30,6 @@ class ActivityEntity extends Entity {
         'photo_id'   => 'string',
         'place_id'   => 'string',
         'rating_id'  => 'string',
-        'comment_id' => 'string'
+        'comment_id' => 'string',
     ];
 }

--- a/server/app/Entities/CategoryEntity.php
+++ b/server/app/Entities/CategoryEntity.php
@@ -13,17 +13,11 @@ class CategoryEntity extends Entity {
         'content_ru' => null,
     ];
 
-    // protected $dates = [
-    //     'created_at',
-    //     'updated_at',
-    //     'deleted_at'
-    // ];
-
     protected $casts = [
         'name'       => 'string',
         'title_en'   => 'string',
         'title_ru'   => 'string',
         'content_en' => 'string',
-        'content_ru' => 'string'
+        'content_ru' => 'string',
     ];
 }

--- a/server/app/Entities/CommentEntity.php
+++ b/server/app/Entities/CommentEntity.php
@@ -10,20 +10,20 @@ class CommentEntity extends Entity {
         'place_id'  => null,
         'user_id'   => null,
         'answer_id' => null,
-        'content'   => null
+        'content'   => null,
     ];
 
     protected $dates = [
         'created_at',
         'updated_at',
-        'deleted_at'
+        'deleted_at',
     ];
 
     protected $casts = [
-        'id'          => 'string',
-        'place_id'    => 'string',
-        'user_id'     => 'string',
-        'answer_id'   => 'string',
-        'content'     => 'string'
+        'id'        => 'string',
+        'place_id'  => 'string',
+        'user_id'   => 'string',
+        'answer_id' => 'string',
+        'content'   => 'string',
     ];
 }

--- a/server/app/Entities/LocationCountryEntity.php
+++ b/server/app/Entities/LocationCountryEntity.php
@@ -8,18 +8,18 @@ class LocationCountryEntity extends Entity {
     protected $attributes = [
         'id'       => null,
         'title_en' => null,
-        'title_ru' => null
+        'title_ru' => null,
     ];
 
     protected $dates = [
         'created_at',
         'updated_at',
-        'deleted_at'
+        'deleted_at',
     ];
 
     protected $casts = [
         'id'       => 'integer',
         'title_en' => 'string',
-        'title_ru' => 'string'
+        'title_ru' => 'string',
     ];
 }

--- a/server/app/Entities/LocationDistrictEntity.php
+++ b/server/app/Entities/LocationDistrictEntity.php
@@ -10,13 +10,13 @@ class LocationDistrictEntity extends Entity {
         'country_id' => null,
         'region_id'  => null,
         'title_en'   => null,
-        'title_ru'   => null
+        'title_ru'   => null,
     ];
 
     protected $dates = [
         'created_at',
         'updated_at',
-        'deleted_at'
+        'deleted_at',
     ];
 
     protected $casts = [
@@ -24,6 +24,6 @@ class LocationDistrictEntity extends Entity {
         'country_id' => 'integer',
         'region_id'  => 'integer',
         'title_en'   => 'string',
-        'title_ru'   => 'string'
+        'title_ru'   => 'string',
     ];
 }

--- a/server/app/Entities/LocationLocalityEntity.php
+++ b/server/app/Entities/LocationLocalityEntity.php
@@ -11,13 +11,13 @@ class LocationLocalityEntity extends Entity {
         'region_id'   => null,
         'district_id' => null,
         'title_en'    => null,
-        'title_ru'    => null
+        'title_ru'    => null,
     ];
 
     protected $dates = [
         'created_at',
         'updated_at',
-        'deleted_at'
+        'deleted_at',
     ];
 
     protected $casts = [
@@ -26,6 +26,6 @@ class LocationLocalityEntity extends Entity {
         'region_id'   => 'integer',
         'district_id' => 'integer',
         'title_en'    => 'string',
-        'title_ru'    => 'string'
+        'title_ru'    => 'string',
     ];
 }

--- a/server/app/Entities/LocationRegionEntity.php
+++ b/server/app/Entities/LocationRegionEntity.php
@@ -9,19 +9,19 @@ class LocationRegionEntity extends Entity {
         'id'         => null,
         'country_id' => null,
         'title_en'   => null,
-        'title_ru'   => null
+        'title_ru'   => null,
     ];
 
     protected $dates = [
         'created_at',
         'updated_at',
-        'deleted_at'
+        'deleted_at',
     ];
 
     protected $casts = [
         'id'         => 'integer',
         'country_id' => 'integer',
         'title_en'   => 'string',
-        'title_ru'   => 'string'
+        'title_ru'   => 'string',
     ];
 }

--- a/server/app/Entities/OverpassCategory.php
+++ b/server/app/Entities/OverpassCategory.php
@@ -5,7 +5,21 @@ namespace App\Entities;
 use CodeIgniter\Entity\Entity;
 
 class OverpassCategory extends Entity {
+    protected $attributes = [
+        'id'           => null,
+        'category'     => null,
+        'subcategory'  => null,
+        'name'         => null,
+        'title'        => null,
+        'category_map' => null,
+    ];
+
     protected $casts = [
-        
+        'id'           => 'integer',
+        'category'     => 'string',
+        'subcategory'  => 'string',
+        'name'         => 'string',
+        'title'        => 'string',
+        'category_map' => 'string',
     ];
 }

--- a/server/app/Entities/PhotoEntity.php
+++ b/server/app/Entities/PhotoEntity.php
@@ -22,7 +22,7 @@ class PhotoEntity extends Entity {
     protected $dates = [
         'created_at',
         'updated_at',
-        'deleted_at'
+        'deleted_at',
     ];
 
     protected $casts = [
@@ -41,7 +41,6 @@ class PhotoEntity extends Entity {
     ];
 
     protected $datamap = [
-        // property_name => db_column_name
-        'created' => 'created_at'
+        'created' => 'created_at',
     ];
 }

--- a/server/app/Entities/PlaceContentEntity.php
+++ b/server/app/Entities/PlaceContentEntity.php
@@ -17,7 +17,7 @@ class PlaceContentEntity extends Entity {
     protected $dates = [
         'created_at',
         'updated_at',
-        'deleted_at'
+        'deleted_at',
     ];
 
     protected $casts = [
@@ -26,6 +26,6 @@ class PlaceContentEntity extends Entity {
         'locale'   => 'string',
         'title'    => 'string',
         'content'  => 'string',
-        'delta'    => 'integer'
+        'delta'    => 'integer',
     ];
 }

--- a/server/app/Entities/PlaceEntity.php
+++ b/server/app/Entities/PlaceEntity.php
@@ -20,13 +20,13 @@ class PlaceEntity extends Entity {
         'region_id'   => null,
         'district_id' => null,
         'locality_id' => null,
-        'user_id'     => null
+        'user_id'     => null,
     ];
 
     protected $dates = [
         'created_at',
         'updated_at',
-        'deleted_at'
+        'deleted_at',
     ];
 
     protected $casts = [
@@ -45,8 +45,7 @@ class PlaceEntity extends Entity {
         'district_id' => 'integer',
         'locality_id' => 'integer',
         'user_id'     => 'string',
-
-        'created' => 'datetime',
-        'updated' => 'datetime',
+        'created'     => 'datetime',
+        'updated'     => 'datetime',
     ];
 }

--- a/server/app/Entities/RatingEntity.php
+++ b/server/app/Entities/RatingEntity.php
@@ -16,7 +16,7 @@ class RatingEntity extends Entity {
     protected $dates = [
         'created_at',
         'updated_at',
-        'deleted_at'
+        'deleted_at',
     ];
 
     protected $casts = [
@@ -24,10 +24,11 @@ class RatingEntity extends Entity {
         'user_id'    => 'string',
         'session_id' => 'string',
         'rating'     => 'string',
-        'value'      => 'integer'
+        'value'      => 'integer',
+        'created'    => 'datetime',
     ];
 
     protected $datamap = [
-        'created' => 'created_at'
+        'created' => 'created_at',
     ];
 }

--- a/server/app/Entities/SendingMailEntity.php
+++ b/server/app/Entities/SendingMailEntity.php
@@ -19,7 +19,7 @@ class SendingMailEntity extends Entity {
     protected $dates = [
         'created_at',
         'updated_at',
-        'deleted_at'
+        'deleted_at',
     ];
 
     protected $casts = [
@@ -30,6 +30,6 @@ class SendingMailEntity extends Entity {
         'locale'      => 'string',
         'subject'     => 'string',
         'message'     => 'string',
-        'sent_email'  => 'string'
+        'sent_email'  => 'string',
     ];
 }

--- a/server/app/Entities/SessionEntity.php
+++ b/server/app/Entities/SessionEntity.php
@@ -10,13 +10,13 @@ class SessionEntity extends Entity {
         'user_id' => null,
         'user_ip' => null,
         'lat'     => null,
-        'lon'     => null
+        'lon'     => null,
     ];
 
     protected $dates = [
         'created_at',
         'updated_at',
-        'deleted_at'
+        'deleted_at',
     ];
 
     protected $casts = [
@@ -24,6 +24,6 @@ class SessionEntity extends Entity {
         'user_id' => 'string',
         'user_ip' => 'string',
         'lat'     => 'float',
-        'lon'     => 'float'
+        'lon'     => 'float',
     ];
 }

--- a/server/app/Entities/TagEntity.php
+++ b/server/app/Entities/TagEntity.php
@@ -8,18 +8,18 @@ class TagEntity extends Entity {
     protected $attributes = [
         'title_en' => null,
         'title_ru' => null,
-        'count'    => 0
+        'count'    => 0,
     ];
 
     protected $dates = [
         'created_at',
         'updated_at',
-        'deleted_at'
+        'deleted_at',
     ];
 
     protected $casts = [
         'title_en' => 'string',
         'title_ru' => 'string',
-        'count'    => 'integer'
+        'count'    => 'integer',
     ];
 }

--- a/server/app/Entities/UserAchievementEntity.php
+++ b/server/app/Entities/UserAchievementEntity.php
@@ -4,8 +4,7 @@ namespace App\Entities;
 
 use CodeIgniter\Entity\Entity;
 
-class UserAchievementEntity extends Entity
-{
+class UserAchievementEntity extends Entity {
     protected $attributes = [
         'id'             => null,
         'user_id'        => null,
@@ -16,9 +15,14 @@ class UserAchievementEntity extends Entity
         'emailed'        => 0,
     ];
 
+    protected $dates = ['earned_at'];
+
     protected $casts = [
-        'notified' => 'integer',
-        'emailed'  => 'integer',
-        'progress' => 'json-array',
+        'id'             => 'string',
+        'user_id'        => 'string',
+        'achievement_id' => 'string',
+        'notified'       => 'integer',
+        'emailed'        => 'integer',
+        'progress'       => 'json-array',
     ];
 }

--- a/server/app/Entities/UserBookmarkEntity.php
+++ b/server/app/Entities/UserBookmarkEntity.php
@@ -7,17 +7,17 @@ use CodeIgniter\Entity\Entity;
 class UserBookmarkEntity extends Entity {
     protected $attributes = [
         'user_id'  => null,
-        'place_id' => null
+        'place_id' => null,
     ];
 
     protected $dates = [
         'created_at',
         'updated_at',
-        'deleted_at'
+        'deleted_at',
     ];
 
     protected $casts = [
         'user_id'  => 'string',
-        'place_id' => 'string'
+        'place_id' => 'string',
     ];
 }

--- a/server/app/Entities/UserEntity.php
+++ b/server/app/Entities/UserEntity.php
@@ -25,7 +25,7 @@ class UserEntity extends Entity {
         'created_at',
         'updated_at',
         'deleted_at',
-        'activity_at'
+        'activity_at',
     ];
 
     protected $casts = [
@@ -43,9 +43,8 @@ class UserEntity extends Entity {
         'avatar'      => 'string',
         'settings'    => 'json',
         'activity_at' => 'datetime',
-
-        'created'  => 'datetime',
-        'activity' => 'datetime',
-        'updated'  => 'datetime',
+        'created'     => 'datetime',
+        'updated'     => 'datetime',
+        'activity'    => 'datetime',
     ];
 }

--- a/server/app/Entities/UserLevelEntity.php
+++ b/server/app/Entities/UserLevelEntity.php
@@ -10,20 +10,14 @@ class UserLevelEntity extends Entity {
         'title_en'   => null,
         'title_ru'   => null,
         'level'      => null,
-        'experience' => null
+        'experience' => null,
     ];
-
-    // protected $dates = [
-    //     'created_at',
-    //     'updated_at',
-    //     'deleted_at'
-    // ];
 
     protected $casts = [
         'id'         => 'integer',
         'title_en'   => 'string',
         'title_ru'   => 'string',
         'level'      => 'integer',
-        'experience' => 'integer'
+        'experience' => 'integer',
     ];
 }

--- a/server/app/Entities/UserNotificationEntity.php
+++ b/server/app/Entities/UserNotificationEntity.php
@@ -16,14 +16,14 @@ class UserNotificationEntity extends Entity {
     protected $dates = [
         'created_at',
         'updated_at',
-        'deleted_at'
+        'deleted_at',
     ];
 
     protected $casts = [
         'type'        => 'string',
-        'read'        => 'bool',
+        'read'        => 'boolean',
         'meta'        => 'json',
         'user_id'     => 'string',
-        'activity_id' => 'string'
+        'activity_id' => 'string',
     ];
 }

--- a/server/app/Entities/UserVisitedPlaceEntity.php
+++ b/server/app/Entities/UserVisitedPlaceEntity.php
@@ -17,7 +17,8 @@ class UserVisitedPlaceEntity extends Entity {
     protected $dates = [
         'created_at',
         'updated_at',
-        'deleted_at'
+        'deleted_at',
+        'visited_at',
     ];
 
     protected $casts = [

--- a/server/app/Libraries/AchievementsLibrary.php
+++ b/server/app/Libraries/AchievementsLibrary.php
@@ -459,15 +459,9 @@ class AchievementsLibrary
 
         $notify = new NotifyLibrary();
         $notify->push('achievements', $userId, null, [
-            'achievement_id' => $achievement->id,
-            'group_slug'     => $achievement->group_slug,
-            'tier'             => $achievement->tier,
-            'title_en'         => $achievement->title_en,
-            'title_ru'         => $achievement->title_ru,
-            'icon'             => $achievement->icon,
-            'image'            => $achievement->image,
-            'xp_bonus'         => $achievement->xp_bonus,
-            'is_upgrade'       => $isUpgrade,
+            'title_en' => $achievement->title_en,
+            'title_ru' => $achievement->title_ru,
+            'image'    => $achievement->image,
         ]);
     }
 

--- a/server/app/Libraries/PlaceFormatterLibrary.php
+++ b/server/app/Libraries/PlaceFormatterLibrary.php
@@ -131,7 +131,8 @@ class PlaceFormatterLibrary
             $row->region_id, $row->region_en, $row->region_ru,
             $row->district_id, $row->district_en, $row->district_ru,
             $row->locality_id, $row->city_en, $row->city_ru,
-            $row->created_at, $row->updated_at, $row->deleted_at
+            $row->created_at, $row->updated_at, $row->deleted_at,
+            $row->visit_radius_m, $row->verification_exempt
         );
     }
 }

--- a/server/app/Models/ActivityModel.php
+++ b/server/app/Models/ActivityModel.php
@@ -107,8 +107,10 @@ class ActivityModel extends ApplicationBaseModel
             $model->where('activity.place_id', $placeId);
         }
 
-        return $model->whereIn('activity.type', ['photo', 'place', 'rating', 'edit', 'comment'])
-            ->orderBy('activity.created_at, activity.type', 'DESC')
+//        return $model->whereIn('activity.type', ['photo', 'place', 'rating', 'edit', 'comment', 'cover'])
+        return $model
+            ->orderBy('activity.created_at', 'DESC')
+            ->orderBy('activity.type', 'DESC')
             ->findAll(min(abs($limit), 100), abs($offset));
     }
 
@@ -149,11 +151,14 @@ class ActivityModel extends ApplicationBaseModel
     ): array {
         return $this->select(
             'activity.*, places.id as place_id, places.category, users.id as user_id, users.name as user_name,
-            users.avatar as user_avatar, photos.filename, photos.extension, photos.width, photos.height'
+            users.avatar as user_avatar, photos.filename, photos.extension, photos.width, photos.height,
+            rating.value, comments.content as comment_text'
         )
             ->join('places', 'activity.place_id = places.id', 'left')
             ->join('photos', 'activity.photo_id = photos.id', 'left')
             ->join('users', 'activity.user_id = users.id', 'left')
+            ->join('rating', 'activity.rating_id = rating.id', 'left')
+            ->join('comments', 'activity.comment_id = comments.id', 'left')
             ->whereNotIn('activity.id', $activityIds)
             ->where('activity.created_at >=', $createdAt)
             ->where('activity.user_id', $userId)

--- a/server/app/Models/PlacesModel.php
+++ b/server/app/Models/PlacesModel.php
@@ -129,7 +129,8 @@ class PlacesModel extends ApplicationBaseModel
                 location_regions.title_en as region_en, location_regions.title_ru as region_ru,
                 location_districts.title_en as district_en, location_districts.title_ru as district_ru,
                 location_localities.title_en as city_en, location_localities.title_ru as city_ru,
-                category.title_ru as category_ru, category.title_en as category_en' . $distanceSQL
+                category.title_ru as category_ru, category.title_en as category_en,
+                places.visit_radius_m, places.verification_exempt' . $distanceSQL
             )
             ->join('users', 'places.user_id = users.id', 'left')
             ->join('category', 'places.category = category.name', 'left')


### PR DESCRIPTION
### Patch Changes

- Activity feed: improved pagination and grouping — Fetch N+1 items as a lookahead and drop the extra to enforce the requested limit. Added recursion depth limit to `addNextActivityItems`. Grouping now compares timestamps (≤600 s) and requires matching `place_id`/`user_id`. Group type priority refined: `place > edit > cover > photo`. Server ordering changed to `created_at DESC, type DESC`; `cover` activity type re-enabled; `rating.value` and `comments.content` joined and selected.
- Activity feed: cover label and scroll cursor fix — Added translation mapping for `ActivityTypes.Cover`. Refactored `IndexPage` scroll handler to derive `cursorDate` from the last item's `created.date`, replacing the previous `items.length` guard. `onScroll` dependencies updated to `[data, isFetching]`.
- Activity feed: scoped cache keys per author/place — `serializeQueryArgs` now namespaces cache keys with endpoint and `author`/`place` (e.g. `endpoint_author_<id>`) to prevent collisions and ensure correct per-query caching. `Cover` activity type re-enabled in `ActivityTypes`.
- Places model: expose `visit_radius_m` and `verification_exempt` — Both fields added to the `SELECT` clause in `PlacesModel` so they are returned by place queries and available for distance calculations and verification logic.
- Entity normalization: casts, dates, formatting — Standardized `$dates`, `$casts`, and array formatting across `UserAchievementEntity`, `UserBookmarkEntity`, `UserEntity`, `UserLevelEntity`, `UserNotificationEntity`, and `UserVisitedPlaceEntity`. Added `earned_at` and `visited_at` to relevant `$dates`; `read` cast changed to `boolean`.
- Entity formatting: `RatingEntity` `created` cast — Added `'created' => 'datetime'` cast to `RatingEntity`. Applied consistent formatting (trailing commas, datamap cleanup) across entity classes.
- Entity formatting: `OverpassCategory` explicit attributes and casts — Added `$attributes` and `$casts` to `OverpassCategory` so properties are properly typed. Removed commented-out `$dates` from `CategoryEntity`. Normalized array formatting across multiple entity classes.
- Places: avatar resolution for visited users — `AvatarLibrary` instantiated in the visited-users query; returned records now map raw `avatar` values to resolved paths via `buildPath('small')`.
- API: normalize place fields to camelCase — Renamed `visit_radius_m` → `visitRadiusM` and `verification_exempt` → `verificationExempt` in API responses. Server controller maps DB snake_case to camelCase and strips the originals; client models updated accordingly.
- Notifications: centralized localization and simplified meta — Server now reads the request locale and builds a simplified `meta` object (`title`, `level`/`image`) for `achievements` and `level` notifications. Client API model updated; notification UI simplified to use `meta.title`, removing locale-dependent rendering.
- Notifications and places: payload trimming and formatter extension — Removed unused fields from the `achievements` notification payload (only `title_en`, `title_ru`, `image` retained). `PlaceFormatterLibrary` extended to include `visit_radius_m` and `verification_exempt` in formatted place rows.