### PR TITLE
Release v1.6.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 1.6.7
+
+### Patch Changes
+
+- Achievements: fix experience recalculation ignoring XP bonuses — `LevelsLibrary::calculate()` now joins `users_achievements` with `achievements` and adds the sum of earned `xp_bonus` values to the activity-based XP before comparing with the stored value. Previously, every profile request wiped achievement XP because `calculate()` only counted activity-table modifiers.
+- Achievements: award delta XP on tier upgrade — `AchievementsLibrary::awardAchievement()` now fetches the previous tier's `xp_bonus` when upgrading and grants only the difference (`new_xp − old_xp`), keeping the stored experience consistent with what `calculate()` would recompute from scratch.
+- Achievements: fix multi-rule progress aggregation — `getProgress()` now iterates all rules instead of only the primary one. `required` is the sum of all rule thresholds; `current` is the sum of `min(actual, threshold)` per rule. Single-rule achievements benefit too: a user with 101 places against a threshold of 10 now shows `10 / 10` instead of `101 / 10`.
+- Achievements: fix tier selection showing wrong tier in grouped list — Replaced the `isCompleted` helper (which used `pct >= 100` and incorrectly flagged multi-rule achievements as done) with tier-order logic: find the highest earned tier by `earned_at`, then display the next tier above it, or the highest earned tier if all are complete, or the lowest tier if none are earned.
+- Achievements: detail modal layout — Refactored `AchievementDetailModal` into a two-column layout: large medal icon on the left (`size={110}`) and all metadata (title, tier badge, description, date, XP) stacked on the right. Added `modalBody`, `modalImageCol`, `modalInfoCol` SASS classes; tightened margins via `gap`.
+- Achievements: `earned_at` typed as `DateTime` — Changed `Achievement.earned_at` in the client API types from `string | null` to `DateTime`, consistent with other date fields.
+
 ## 1.6.6
 
 ### Patch Changes

--- a/client/api/types/achievements.ts
+++ b/client/api/types/achievements.ts
@@ -1,3 +1,5 @@
+import { DateTime } from '@/api/types/index'
+
 export type AchievementTier = 'none' | 'bronze' | 'silver' | 'gold'
 export type AchievementType = 'base' | 'seasonal'
 export type AchievementCategory = 'exploration' | 'content' | 'social' | 'reputation' | 'consistency' | 'seasonal'
@@ -20,7 +22,7 @@ export interface Achievement {
     xp_bonus: number
     season_start: string | null
     season_end: string | null
-    earned_at: string | null
+    earned_at: DateTime
     progress: AchievementProgress | null
     sort_order: number
     is_active: boolean

--- a/client/components/pages/achievements-list/AchievementsList.tsx
+++ b/client/components/pages/achievements-list/AchievementsList.tsx
@@ -21,20 +21,23 @@ const TIER_PROGRESSION: Partial<Record<ApiType.Achievements.AchievementTier, num
     gold: 3
 }
 
-function isCompleted(a: ApiType.Achievements.Achievement): boolean {
-    return !!a.earned_at || (a.progress !== null && a.progress.pct >= 100) // eslint-disable-line eqeqeq
-}
-
 function pickCurrentFromGroup(items: ApiType.Achievements.Achievement[]): ApiType.Achievements.Achievement {
-    const uncompleted = items.filter((a) => !isCompleted(a))
+    const lowestTier = (list: ApiType.Achievements.Achievement[]) =>
+        list.reduce((best, a) => ((TIER_PROGRESSION[a.tier] ?? 0) < (TIER_PROGRESSION[best.tier] ?? 0) ? a : best))
 
-    if (uncompleted.length > 0) {
-        return uncompleted.reduce((best, a) =>
-            (TIER_PROGRESSION[a.tier] ?? 0) < (TIER_PROGRESSION[best.tier] ?? 0) ? a : best
-        )
+    const highestTier = (list: ApiType.Achievements.Achievement[]) =>
+        list.reduce((best, a) => ((TIER_PROGRESSION[a.tier] ?? 0) > (TIER_PROGRESSION[best.tier] ?? 0) ? a : best))
+
+    const earned = items.filter((a) => !!a.earned_at)
+
+    if (earned.length === 0) {
+        return lowestTier(items)
     }
 
-    return items.reduce((best, a) => ((TIER_PROGRESSION[a.tier] ?? 0) > (TIER_PROGRESSION[best.tier] ?? 0) ? a : best))
+    const highestEarnedOrder = Math.max(...earned.map((a) => TIER_PROGRESSION[a.tier] ?? 0))
+    const nextTargets = items.filter((a) => (TIER_PROGRESSION[a.tier] ?? 0) > highestEarnedOrder)
+
+    return nextTargets.length > 0 ? lowestTier(nextTargets) : highestTier(earned)
 }
 
 interface AchievementsListProps {

--- a/client/components/shared/achievement-card/AchievementBadge.tsx
+++ b/client/components/shared/achievement-card/AchievementBadge.tsx
@@ -34,7 +34,7 @@ export const AchievementBadge: React.FC<AchievementBadgeProps> = ({ achievement 
                 <AchievementIcon
                     image={achievement.image}
                     alt={achievement.title}
-                    size={36}
+                    size={58}
                 />
                 {hovered && (
                     <div
@@ -44,7 +44,7 @@ export const AchievementBadge: React.FC<AchievementBadgeProps> = ({ achievement 
                         <div>
                             <strong>{achievement.title}</strong>
                         </div>
-                        {achievement.earned_at && <div>{formatDate(achievement.earned_at, 'D MMMM YYYY')}</div>}
+                        {achievement.earned_at && <div>{formatDate(achievement.earned_at.date, 'D MMMM YYYY')}</div>}
                     </div>
                 )}
             </div>

--- a/client/components/shared/achievement-card/AchievementCard.tsx
+++ b/client/components/shared/achievement-card/AchievementCard.tsx
@@ -26,7 +26,7 @@ export const AchievementCard: React.FC<AchievementCardProps> = ({ achievement, s
                 <AchievementIcon
                     image={achievement.image}
                     alt={achievement.title}
-                    size={36}
+                    size={50}
                 />
                 <div className={styles.cardMeta}>
                     <p className={styles.cardTitle}>{achievement.title}</p>
@@ -59,7 +59,7 @@ export const AchievementCard: React.FC<AchievementCardProps> = ({ achievement, s
             {achievement.earned_at && (
                 <div className={styles.earnedBadge}>
                     <Icon name={'CheckCircle'} />
-                    {t('achievements-earned-at', { date: formatDate(achievement.earned_at, 'D MMMM YYYY') })}
+                    {t('achievements-earned-at', { date: formatDate(achievement.earned_at.date, 'D MMMM YYYY') })}
                 </div>
             )}
 

--- a/client/components/shared/achievement-card/AchievementDetailModal.tsx
+++ b/client/components/shared/achievement-card/AchievementDetailModal.tsx
@@ -32,35 +32,39 @@ export const AchievementDetailModal: React.FC<AchievementDetailModalProps> = ({ 
             <Icon name={'Close'} />
         </button>
 
-        <div className={styles.modalHeader}>
-            <AchievementIcon
-                image={achievement.image}
-                alt={achievement.title}
-                size={48}
-            />
-            <div>
+        <div className={styles.modalBody}>
+            <div className={styles.modalImageCol}>
+                <AchievementIcon
+                    image={achievement.image}
+                    alt={achievement.title}
+                    size={136}
+                />
+            </div>
+
+            <div className={styles.modalInfoCol}>
                 <h2 className={styles.modalTitle}>{achievement.title}</h2>
+
                 <AchievementTierBadge
                     tier={achievement.tier}
                     t={t}
                 />
+
+                {achievement.description && <p className={styles.modalDescription}>{achievement.description}</p>}
+
+                {achievement.earned_at && (
+                    <p className={styles.modalMeta}>
+                        {t('achievements-earned-at', {
+                            date: formatDate(achievement.earned_at.date, 'D MMMM YYYY')
+                        })}
+                    </p>
+                )}
+
+                {achievement.xp_bonus > 0 && (
+                    <p className={styles.modalMeta}>
+                        {t('achievements-xp-bonus')}: <strong>+{achievement.xp_bonus} XP</strong>
+                    </p>
+                )}
             </div>
         </div>
-
-        {achievement.description && <p className={styles.modalDescription}>{achievement.description}</p>}
-
-        {achievement.earned_at && (
-            <p className={styles.modalMeta}>
-                {t('achievements-earned-at', {
-                    date: formatDate(achievement.earned_at, 'D MMMM YYYY')
-                })}
-            </p>
-        )}
-
-        {achievement.xp_bonus > 0 && (
-            <p className={styles.modalMeta}>
-                {t('achievements-xp-bonus')}: <strong>+{achievement.xp_bonus} XP</strong>
-            </p>
-        )}
     </Dialog>
 )

--- a/client/components/shared/achievement-card/styles.module.sass
+++ b/client/components/shared/achievement-card/styles.module.sass
@@ -125,6 +125,7 @@
 .badgeItem
     position: relative
     cursor: pointer
+    outline: none
 
 .badgeTooltip
     position: absolute
@@ -245,11 +246,23 @@
         &--#{$tier}
             border-top: 4px solid var(--color-tier-#{$tier})
 
-.modalHeader
+.modalBody
+    display: flex
+    align-items: flex-start
+    gap: 20px
+
+.modalImageCol
+    flex-shrink: 0
     display: flex
     align-items: center
-    gap: 14px
-    margin-bottom: 16px
+    justify-content: center
+
+.modalInfoCol
+    flex: 1
+    min-width: 0
+    display: flex
+    flex-direction: column
+    gap: 8px
 
 .modalTitle
     margin: 0
@@ -257,12 +270,12 @@
     color: var(--text-color-primary)
 
 .modalDescription
-    margin: 0 0 12px
+    margin: 0
     font-size: variables.$fontSizeParagraph
     color: var(--text-color-secondary)
     line-height: 1.5
 
 .modalMeta
-    margin: 0 0 8px
+    margin: 0
     font-size: variables.$fontSizeCaption
     color: var(--text-color-secondary)

--- a/client/components/shared/achievement-icon/AchievementIcon.tsx
+++ b/client/components/shared/achievement-icon/AchievementIcon.tsx
@@ -32,7 +32,7 @@ export const AchievementIcon: React.FC<AchievementIconProps> = ({ image, alt = '
         <Image
             src={src}
             alt={alt}
-            width={size}
+            width={size / 1.414}
             height={size}
             unoptimized
             className={className}

--- a/client/components/shared/achievement-tier-badge/styles.module.sass
+++ b/client/components/shared/achievement-tier-badge/styles.module.sass
@@ -4,6 +4,7 @@
     font-size: variables.$fontSizeCaption
     font-weight: 500
     border-radius: 10px
+    width: max-content
 
 @each $tier in 'bronze', 'silver', 'gold'
     .tier--#{$tier}

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "geometki",
-    "version": "1.6.6",
+    "version": "1.6.7",
     "private": true,
     "engines": {
         "node": ">=20.11.0"

--- a/client/sections/user/user-header/styles.module.sass
+++ b/client/sections/user/user-header/styles.module.sass
@@ -123,8 +123,6 @@
         display: flex
         flex-wrap: wrap
         gap: 8px
-        padding-top: 15px
-        border-top: 1px solid var(--border-color)
         width: 100%
 
     .header

--- a/server/app/Libraries/AchievementsLibrary.php
+++ b/server/app/Libraries/AchievementsLibrary.php
@@ -207,10 +207,18 @@ class AchievementsLibrary
             $from = ($achievement->type === 'seasonal') ? $achievement->season_start : null;
             $to   = ($achievement->type === 'seasonal') ? $achievement->season_end   : null;
 
-            $primaryRule = $rules[0];
-            $current     = $this->resolveMetric($userId, $primaryRule, $from, $to);
-            $required    = (int) $primaryRule['value'];
-            $pct         = $required > 0 ? min(100.0, round(($current / $required) * 100, 1)) : 100.0;
+            $current  = 0;
+            $required = 0;
+
+            foreach ($rules as $rule) {
+                $threshold = (int) $rule['value'];
+                $actual    = $this->resolveMetric($userId, $rule, $from, $to);
+
+                $required += $threshold;
+                $current  += min($actual, $threshold);
+            }
+
+            $pct = $required > 0 ? min(100.0, round(($current / $required) * 100, 1)) : 100.0;
 
             $result[$achievement->id] = [
                 'current'  => $current,
@@ -449,11 +457,22 @@ class AchievementsLibrary
             $userAchievementsModel->insert($entity);
         }
 
-        if ($achievement->xp_bonus > 0) {
+        $xpDelta = $achievement->xp_bonus;
+        if ($isUpgrade) {
+            $oldAchievementId = $earnedGroupMap[$achievement->group_slug]['achievement_id'];
+            $db               = \Config\Database::connect();
+            $oldRow           = $db->table('achievements')
+                ->select('xp_bonus')
+                ->where('id', $oldAchievementId)
+                ->get()->getRow();
+            $xpDelta = max(0, $achievement->xp_bonus - (int) ($oldRow->xp_bonus ?? 0));
+        }
+
+        if ($xpDelta > 0) {
             $db = \Config\Database::connect();
             $db->query(
-                "UPDATE users SET experience = experience + ? WHERE id = ?",
-                [$achievement->xp_bonus, $userId]
+                'UPDATE users SET experience = experience + ? WHERE id = ?',
+                [$xpDelta, $userId]
             );
         }
 

--- a/server/app/Libraries/LevelsLibrary.php
+++ b/server/app/Libraries/LevelsLibrary.php
@@ -64,6 +64,17 @@ class LevelsLibrary {
         $experience += $statistic->cover * MODIFIER_COVER;
         $experience += $statistic->comment * MODIFIER_COMMENT;
 
+        // Add XP bonuses from earned achievements (only current tier per group)
+        $db  = \Config\Database::connect();
+        $row = $db->query(
+            'SELECT COALESCE(SUM(a.xp_bonus), 0) AS achievement_xp
+             FROM users_achievements ua
+             JOIN achievements a ON a.id = ua.achievement_id
+             WHERE ua.user_id = ?',
+            [$user->id]
+        )->getRow();
+        $experience += (int) ($row->achievement_xp ?? 0);
+
         $this->statistic = $statistic;
 
         // Let's see what level the user should actually have


### PR DESCRIPTION
### Patch Changes

- Achievements: fix experience recalculation ignoring XP bonuses — `LevelsLibrary::calculate()` now joins `users_achievements` with `achievements` and adds the sum of earned `xp_bonus` values to the activity-based XP before comparing with the stored value. Previously, every profile request wiped achievement XP because `calculate()` only counted activity-table modifiers.
- Achievements: award delta XP on tier upgrade — `AchievementsLibrary::awardAchievement()` now fetches the previous tier's `xp_bonus` when upgrading and grants only the difference (`new_xp − old_xp`), keeping the stored experience consistent with what `calculate()` would recompute from scratch.
- Achievements: fix multi-rule progress aggregation — `getProgress()` now iterates all rules instead of only the primary one. `required` is the sum of all rule thresholds; `current` is the sum of `min(actual, threshold)` per rule. Single-rule achievements benefit too: a user with 101 places against a threshold of 10 now shows `10 / 10` instead of `101 / 10`.
- Achievements: fix tier selection showing wrong tier in grouped list — Replaced the `isCompleted` helper (which used `pct >= 100` and incorrectly flagged multi-rule achievements as done) with tier-order logic: find the highest earned tier by `earned_at`, then display the next tier above it, or the highest earned tier if all are complete, or the lowest tier if none are earned.
- Achievements: detail modal layout — Refactored `AchievementDetailModal` into a two-column layout: large medal icon on the left (`size={110}`) and all metadata (title, tier badge, description, date, XP) stacked on the right. Added `modalBody`, `modalImageCol`, `modalInfoCol` SASS classes; tightened margins via `gap`.
- Achievements: `earned_at` typed as `DateTime` — Changed `Achievement.earned_at` in the client API types from `string | null` to `DateTime`, consistent with other date fields.
