### PR TITLE
Enhance place schema.org structured data

### DIFF
--- a/client/pages/places/[id]/index.tsx
+++ b/client/pages/places/[id]/index.tsx
@@ -124,11 +124,13 @@ const PlacePage: NextPage<PlacePageProps> = ({ ratingCount, place, photoList, ne
     const placeSchema = useMemo(
         () => ({
             '@context': 'https://schema.org',
-            '@type': 'TouristAttraction',
+            '@type': ['TouristAttraction', 'LocalBusiness'],
             '@id': pagePlaceUrl,
             address: {
                 '@type': 'PostalAddress',
-                addressCountry: place?.address?.country?.name,
+                addressCountry: place?.address?.country?.name
+                    ? { '@type': 'Country', name: place.address.country.name }
+                    : undefined,
                 addressLocality: place?.address?.locality?.name,
                 addressRegion: place?.address?.region?.name,
                 streetAddress: place?.address?.street
@@ -137,8 +139,8 @@ const PlacePage: NextPage<PlacePageProps> = ({ ratingCount, place, photoList, ne
                 ? {
                       '@type': 'AggregateRating',
                       bestRating: '5',
-                      ratingCount: ratingCount ?? 0,
-                      ratingValue: place?.rating,
+                      ratingCount: ratingCount,
+                      ratingValue: String(place?.rating),
                       worstRating: '1'
                   }
                 : undefined,


### PR DESCRIPTION
Update the JSON-LD for place pages to provide richer and more accurate structured data: add 'LocalBusiness' alongside 'TouristAttraction', represent addressCountry as a Country object when a country name exists, and adjust rating fields by removing the default 0 for ratingCount and casting ratingValue to a string. These changes improve semantic accuracy for search engines and avoid emitting misleading default values.