### PR TITLE
Deploy i18n config, update 404 and build copy

### DIFF
--- a/.github/workflows/ui-deploy.yml
+++ b/.github/workflows/ui-deploy.yml
@@ -99,6 +99,7 @@ jobs:
           rsync -avz -e ssh client/.next/static vps:/var/www/geometki.com/.next
           rsync -avz -e ssh client/public vps:/var/www/geometki.com
           rsync -avz -e ssh client/ecosystem.config.js vps:/var/www/geometki.com
+          rsync -avz -e ssh client/next-i18next.config.js vps:/var/www/geometki.com
 
       # For the first launch of the application on the server:
       # pm2 start ecosystem.config.js && pm2 save

--- a/client/app/not-found.tsx
+++ b/client/app/not-found.tsx
@@ -1,11 +1,15 @@
-'use client'
+import type { Metadata } from 'next'
 
-import { useRouter } from 'next/navigation'
+import { NotFoundPage } from '@/components/shared/not-found-page'
 
-import { NotFoundPage } from '@/components/shared'
+export const metadata: Metadata = {
+    robots: {
+        follow: false,
+        index: false
+    },
+    title: 'Место не найдено | Геометки'
+}
 
 export default function NotFound() {
-    const router = useRouter()
-
-    return <NotFoundPage onBack={() => router.back()} />
+    return <NotFoundPage />
 }

--- a/client/components/shared/not-found-page/NotFoundPage.tsx
+++ b/client/components/shared/not-found-page/NotFoundPage.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React from 'react'
 
 import Image from 'next/image'

--- a/client/package.json
+++ b/client/package.json
@@ -7,7 +7,7 @@
     },
     "scripts": {
         "dev": "next dev",
-        "build": "next build",
+        "build": "next build && cp -r .next/server/chunks/ssr/. .next/standalone/.next/server/chunks/ssr && cp next-i18next.config.js .next/standalone/",
         "export": "next build && next export",
         "start": "next start",
         "test": "jest",


### PR DESCRIPTION
Add next-i18next.config.js to deployment rsync so the server receives i18n config. Modify the build script to copy SSR chunks into the standalone output and include next-i18next.config.js in .next/standalone so i18n works in standalone deployments. Update client/app/not-found.tsx to use Next Metadata (set robots noindex and page title) and remove the client-side back handler.