### PR TITLE
Adjust users-list mobile grid layout

### DIFF
--- a/client/components/shared/users-list/styles.module.sass
+++ b/client/components/shared/users-list/styles.module.sass
@@ -29,9 +29,13 @@
         grid-template-columns: minmax(190px, 2fr) minmax(150px, 2fr) minmax(80px, 1fr)
         grid-template-areas: "user level reputation"
 
+        @media only screen and (max-width: variables.$mobileMaxWidth)
+            grid-template-columns: 1fr auto
+            grid-template-areas: "user badge"
+
     @media only screen and (max-width: variables.$mobileMaxWidth)
         grid-template-columns: 1fr auto
-        grid-template-areas: "user badge" "meta meta" "stats stats"
+        grid-template-areas: "user badge" "stats stats"
         column-gap: 4px
         row-gap: 4px
 


### PR DESCRIPTION
Add a mobile breakpoint to the users-list grid (max-width: variables.$mobileMaxWidth) to switch columns to 1fr / auto and set grid areas to "user badge". Remove the redundant "meta meta" row from the existing mobile grid-template-areas so that "stats" spans full width on mobile, simplifying the compact layout.